### PR TITLE
fix: Allow YAML files to have no extension

### DIFF
--- a/backends/file/client.go
+++ b/backends/file/client.go
@@ -46,7 +46,7 @@ func readFile(path string, vars map[string]string) error {
 			return err
 		}
 		err = nodeWalk(fileMap, "/", vars)
-	case ".yml", ".yaml":
+	case "", ".yml", ".yaml":
 		fileMap := make(map[interface{}]interface{})
 		err = yaml.Unmarshal(data, &fileMap)
 		if err != nil {

--- a/integration/file/test_yaml.sh
+++ b/integration/file/test_yaml.sh
@@ -2,7 +2,7 @@
 
 export HOSTNAME="localhost"
 mkdir backends1 backends2
-cat <<EOT >> backends1/1.yaml
+cat <<EOT >> backends1/1
 key: foobar
 database:
   host: 127.0.0.1
@@ -11,7 +11,7 @@ database:
   username: confd
 EOT
 
-cat <<EOT >> backends1/2.yaml
+cat <<EOT >> backends1/2.yml
 upstream:
   app1: 10.0.1.10:8080
   app2: 10.0.1.11:8080


### PR DESCRIPTION
The file extension wasn't used previously to determine if a file was yaml.
So the addition of JSON and thus checking of extensions introduced a
scenario where yaml files without extension resulted in an error. This
change allows resets the default behavior that a file with no extension
is assumed to be yaml.

Added integration tests to test all three variants