### PR TITLE
fix: Allow connections to SSL sites without certs

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -48,7 +48,7 @@ func New(config Config) (StoreClient, error) {
 			config.Password,
 		)
 	case "etcd":
-		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.BasicAuth, config.Username, config.Password)
+		return etcd.NewEtcdClient(backendNodes, config.ClientCert, config.ClientKey, config.ClientCaKeys, config.ClientInsecure, config.BasicAuth, config.Username, config.Password)
 	case "zookeeper":
 		return zookeeper.NewZookeeperClient(backendNodes)
 	case "rancher":

--- a/backends/etcd/client.go
+++ b/backends/etcd/client.go
@@ -106,7 +106,7 @@ type Client struct {
 }
 
 // NewEtcdClient returns an *etcd.Client with a connection to named machines.
-func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, username string, password string) (*Client, error) {
+func NewEtcdClient(machines []string, cert, key, caCert string, clientInsecure bool, basicAuth bool, username string, password string) (*Client, error) {
 	cfg := clientv3.Config{
 		Endpoints:            machines,
 		DialTimeout:          5 * time.Second,
@@ -121,7 +121,7 @@ func NewEtcdClient(machines []string, cert, key, caCert string, basicAuth bool, 
 
 	tlsEnabled := false
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: false,
+		InsecureSkipVerify: clientInsecure,
 	}
 
 	if caCert != "" {


### PR DESCRIPTION
Allow connections to SSL sites without certs (backend = etcd)

cli
```
-client-insecure
```

toml
```
client_insecure = true
```