### PR TITLE
Pin integration test container to 22.04 for now

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: ubuntu:latest
+    container: ubuntu:22.04
 
     # Service containers to run with `container-job`
     services:


### PR DESCRIPTION
Things have changed in 24.04 enough that deps aren't installing. Pinning to 22.04 is an acceptable fix for the time being.