### PR TITLE
Update deprecated use of ioutil

### DIFF
--- a/cmd/confd/config.go
+++ b/cmd/confd/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -85,7 +84,7 @@ func initConfig() error {
 		log.Debug("Skipping confd config file.")
 	} else {
 		log.Debug("Loading " + config.ConfigFile)
-		configBytes, err := ioutil.ReadFile(config.ConfigFile)
+		configBytes, err := os.ReadFile(config.ConfigFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/backends/etcd/client.go
+++ b/pkg/backends/etcd/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -124,7 +124,7 @@ func NewEtcdClient(machines []string, cert, key, caCert string, clientInsecure b
 	}
 
 	if caCert != "" {
-		certBytes, err := ioutil.ReadFile(caCert)
+		certBytes, err := os.ReadFile(caCert)
 		if err != nil {
 			return &Client{}, err
 		}

--- a/pkg/backends/file/client.go
+++ b/pkg/backends/file/client.go
@@ -3,7 +3,7 @@ package file
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -33,7 +33,7 @@ func NewFileClient(filepath []string, filter string) (*Client, error) {
 }
 
 func readFile(path string, vars map[string]string) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -174,7 +173,7 @@ func (t *TemplateResource) createStageFile() error {
 	}
 
 	// create TempFile in Dest directory to avoid cross-filesystem issues
-	temp, err := ioutil.TempFile(filepath.Dir(t.Dest), "."+filepath.Base(t.Dest))
+	temp, err := os.CreateTemp(filepath.Dir(t.Dest), "."+filepath.Base(t.Dest))
 	if err != nil {
 		return err
 	}
@@ -231,11 +230,11 @@ func (t *TemplateResource) sync() error {
 				// try to open the file and write to it
 				var contents []byte
 				var rerr error
-				contents, rerr = ioutil.ReadFile(staged)
+				contents, rerr = os.ReadFile(staged)
 				if rerr != nil {
 					return rerr
 				}
-				err := ioutil.WriteFile(t.Dest, contents, t.FileMode)
+				err := os.WriteFile(t.Dest, contents, t.FileMode)
 				// make sure owner and group match the temp file, in case the file was created with WriteFile
 				os.Chown(t.Dest, t.Uid, t.Gid)
 				if err != nil {

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 // confd confDir.
 // It returns an error if any.
 func createTempDirs() (string, error) {
-	confDir, err := ioutil.TempDir("", "")
+	confDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -51,13 +50,13 @@ func TestProcessTemplateResources(t *testing.T) {
 
 	// Create the src template.
 	srcTemplateFile := filepath.Join(tempConfDir, "templates", "foo.tmpl")
-	err = ioutil.WriteFile(srcTemplateFile, []byte(`foo = {{getv "/foo"}}`), 0644)
+	err = os.WriteFile(srcTemplateFile, []byte(`foo = {{getv "/foo"}}`), 0644)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	// Create the dest.
-	destFile, err := ioutil.TempFile("", "")
+	destFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Errorf("Failed to create destFile: %s", err.Error())
 	}
@@ -99,7 +98,7 @@ func TestProcessTemplateResources(t *testing.T) {
 	}
 	// Verify the results.
 	expected := "foo = bar"
-	results, err := ioutil.ReadFile(destFile.Name())
+	results, err := os.ReadFile(destFile.Name())
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -569,7 +568,7 @@ func ExecuteTestTemplate(tt templateTest, t *testing.T) {
 		t.Errorf(tt.desc + ": failed createStageFile: " + err.Error())
 	}
 
-	actual, err := ioutil.ReadFile(tr.StageFile.Name())
+	actual, err := os.ReadFile(tr.StageFile.Name())
 	if err != nil {
 		t.Errorf(tt.desc + ": failed to read StageFile: " + err.Error())
 	}
@@ -595,14 +594,14 @@ func setupDirectoriesAndFiles(tt templateTest, t *testing.T) {
 	if err := os.MkdirAll("./test/confd", os.ModePerm); err != nil {
 		t.Errorf(tt.desc + ": failed to created confd directory: " + err.Error())
 	}
-	if err := ioutil.WriteFile(tomlFilePath, []byte(tt.toml), os.ModePerm); err != nil {
+	if err := os.WriteFile(tomlFilePath, []byte(tt.toml), os.ModePerm); err != nil {
 		t.Errorf(tt.desc + ": failed to write toml file: " + err.Error())
 	}
 	// create templates directory and tmpl file
 	if err := os.MkdirAll("./test/templates", os.ModePerm); err != nil {
 		t.Errorf(tt.desc + ": failed to create template directory: " + err.Error())
 	}
-	if err := ioutil.WriteFile(tmplFilePath, []byte(tt.tmpl), os.ModePerm); err != nil {
+	if err := os.WriteFile(tmplFilePath, []byte(tt.tmpl), os.ModePerm); err != nil {
 		t.Errorf(tt.desc + ": failed to write toml file: " + err.Error())
 	}
 	// create tmp directory for output

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,26 +15,27 @@ import (
 // │   ├── sym1.toml
 // │   └── sym2.toml
 // └── root
-//     ├── root.other1
-//     ├── root.toml
-//     ├── subDir1
-//     │   ├── sub1.other
-//     │   ├── sub1.toml
-//     │   └── sub12.toml
-//     ├── subDir2
-//     │   ├── sub2.other
-//     │   ├── sub2.toml
-//     │   ├── sub22.toml
-//     │   └── subSubDir
-//     │       ├── subsub.other
-//     │       ├── subsub.toml
-//     │       ├── subsub2.toml
-//     │       └── sym2.toml -> ../../../other/sym2.toml
-//     └── sym1.toml -> ../other/sym1.toml
+//
+//	├── root.other1
+//	├── root.toml
+//	├── subDir1
+//	│   ├── sub1.other
+//	│   ├── sub1.toml
+//	│   └── sub12.toml
+//	├── subDir2
+//	│   ├── sub2.other
+//	│   ├── sub2.toml
+//	│   ├── sub22.toml
+//	│   └── subSubDir
+//	│       ├── subsub.other
+//	│       ├── subsub.toml
+//	│       ├── subsub2.toml
+//	│       └── sym2.toml -> ../../../other/sym2.toml
+//	└── sym1.toml -> ../other/sym1.toml
 func createDirStructure() (string, error) {
 	mod := os.FileMode(0755)
 	flag := os.O_RDWR | os.O_CREATE | os.O_EXCL
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -178,7 +178,7 @@ func TestRecursiveFilesLookup(t *testing.T) {
 
 func TestIsConfigChangedTrue(t *testing.T) {
 	log.SetLevel("warn")
-	src, err := ioutil.TempFile("", "src")
+	src, err := os.CreateTemp("", "src")
 	defer os.Remove(src.Name())
 	if err != nil {
 		t.Errorf(err.Error())
@@ -187,7 +187,7 @@ func TestIsConfigChangedTrue(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	dest, err := ioutil.TempFile("", "dest")
+	dest, err := os.CreateTemp("", "dest")
 	defer os.Remove(dest.Name())
 	if err != nil {
 		t.Errorf(err.Error())
@@ -207,7 +207,7 @@ func TestIsConfigChangedTrue(t *testing.T) {
 
 func TestIsConfigChangedFalse(t *testing.T) {
 	log.SetLevel("warn")
-	src, err := ioutil.TempFile("", "src")
+	src, err := os.CreateTemp("", "src")
 	defer os.Remove(src.Name())
 	if err != nil {
 		t.Errorf(err.Error())
@@ -216,7 +216,7 @@ func TestIsConfigChangedFalse(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	dest, err := ioutil.TempFile("", "dest")
+	dest, err := os.CreateTemp("", "dest")
 	defer os.Remove(dest.Name())
 	if err != nil {
 		t.Errorf(err.Error())

--- a/test/integration/zookeeper/main.go
+++ b/test/integration/zookeeper/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -55,7 +54,7 @@ func parsejson(prefix string, x interface{}, c *zk.Conn) {
 
 func main() {
 	var pj interface{}
-	dat, err := ioutil.ReadFile("test.json")
+	dat, err := os.ReadFile("test.json")
 	check(err)
 	err = json.Unmarshal(dat, &pj)
 	check(err)


### PR DESCRIPTION
> Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.
https://pkg.go.dev/io/ioutil