### PR TITLE
test: improve test coverage from 13% to 40%

### DIFF
--- a/pkg/backends/client_test.go
+++ b/pkg/backends/client_test.go
@@ -1,0 +1,137 @@
+package backends
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNew_InvalidBackend(t *testing.T) {
+	config := Config{
+		Backend: "invalid",
+	}
+
+	_, err := New(config)
+	if err == nil {
+		t.Error("New() expected error for invalid backend, got nil")
+	}
+	if err.Error() != "Invalid backend" {
+		t.Errorf("New() error = %v, want 'Invalid backend'", err)
+	}
+}
+
+func TestNew_EnvBackend(t *testing.T) {
+	config := Config{
+		Backend: "env",
+	}
+
+	client, err := New(config)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client for env backend")
+	}
+}
+
+func TestNew_FileBackend(t *testing.T) {
+	// Create a temp YAML file
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(yamlFile, []byte("key: value"), 0644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	config := Config{
+		Backend:  "file",
+		YAMLFile: []string{yamlFile},
+	}
+
+	client, err := New(config)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client for file backend")
+	}
+}
+
+func TestNew_DefaultBackendIsEtcd(t *testing.T) {
+	// When backend is empty, it should default to etcd
+	// We can't fully test this without an etcd server, but we can verify
+	// the code path attempts etcd
+	config := Config{
+		Backend:      "",
+		BackendNodes: []string{"http://localhost:2379"},
+	}
+
+	// This will fail to connect, but we can verify it tries etcd
+	_, err := New(config)
+	// Error is expected since there's no etcd server
+	// The important thing is it doesn't return "Invalid backend"
+	if err != nil && err.Error() == "Invalid backend" {
+		t.Error("New() with empty backend should default to etcd, not return 'Invalid backend'")
+	}
+}
+
+func TestStoreClient_Interface(t *testing.T) {
+	// Verify that our backends implement the StoreClient interface
+	config := Config{
+		Backend: "env",
+	}
+
+	client, err := New(config)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	// Test GetValues
+	t.Setenv("TEST_KEY", "test_value")
+	values, err := client.GetValues([]string{"/test/key"})
+	if err != nil {
+		t.Errorf("GetValues() unexpected error: %v", err)
+	}
+	if values["/test/key"] != "test_value" {
+		t.Errorf("GetValues() = %v, want map with /test/key: test_value", values)
+	}
+}
+
+func TestNew_FileBackend_GetValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+database:
+  host: localhost
+  port: "5432"
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	config := Config{
+		Backend:  "file",
+		YAMLFile: []string{yamlFile},
+	}
+
+	client, err := New(config)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	values, err := client.GetValues([]string{"/database"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	if values["/database/host"] != "localhost" {
+		t.Errorf("GetValues()['/database/host'] = %s, want 'localhost'", values["/database/host"])
+	}
+	if values["/database/port"] != "5432" {
+		t.Errorf("GetValues()['/database/port'] = %s, want '5432'", values["/database/port"])
+	}
+}
+
+// Note: Testing other backends (consul, etcd, redis, zookeeper, vault, dynamodb, ssm)
+// requires running backend services. These are covered by integration tests in
+// .github/workflows/integration-tests.yml

--- a/pkg/backends/consul/client.go
+++ b/pkg/backends/consul/client.go
@@ -7,9 +7,15 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-// Client provides a wrapper around the consulkv client
+// consulKVAPI defines the interface for Consul KV operations used by this client.
+// This allows for easy mocking in tests.
+type consulKVAPI interface {
+	List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
+}
+
+// ConsulClient provides a wrapper around the consulkv client
 type ConsulClient struct {
-	client *api.KV
+	client consulKVAPI
 }
 
 // NewConsulClient returns a new client to Consul for the given address

--- a/pkg/backends/consul/client_test.go
+++ b/pkg/backends/consul/client_test.go
@@ -1,0 +1,245 @@
+package consul
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+)
+
+// mockConsulKV implements the consulKVAPI interface for testing
+type mockConsulKV struct {
+	listFunc func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
+}
+
+func (m *mockConsulKV) List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+	if m.listFunc != nil {
+		return m.listFunc(prefix, q)
+	}
+	return nil, &api.QueryMeta{}, nil
+}
+
+// newTestClient creates a ConsulClient with a mock KV for testing
+func newTestClient(mock *mockConsulKV) *ConsulClient {
+	return &ConsulClient{
+		client: mock,
+	}
+}
+
+func TestGetValues_SingleKey(t *testing.T) {
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			if prefix == "app/config" {
+				return api.KVPairs{
+					&api.KVPair{Key: "app/config/key", Value: []byte("value")},
+				}, &api.QueryMeta{}, nil
+			}
+			return nil, &api.QueryMeta{}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/app/config"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{"/app/config/key": "value"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MultipleKeys(t *testing.T) {
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			switch prefix {
+			case "db":
+				return api.KVPairs{
+					&api.KVPair{Key: "db/host", Value: []byte("localhost")},
+				}, &api.QueryMeta{}, nil
+			case "cache":
+				return api.KVPairs{
+					&api.KVPair{Key: "cache/host", Value: []byte("redis")},
+				}, &api.QueryMeta{}, nil
+			}
+			return nil, &api.QueryMeta{}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/db", "/cache"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/db/host":    "localhost",
+		"/cache/host": "redis",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MultiplePairs(t *testing.T) {
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			return api.KVPairs{
+				&api.KVPair{Key: "app/db/host", Value: []byte("localhost")},
+				&api.KVPair{Key: "app/db/port", Value: []byte("5432")},
+				&api.KVPair{Key: "app/db/name", Value: []byte("mydb")},
+			}, &api.QueryMeta{}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/app/db"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/app/db/host": "localhost",
+		"/app/db/port": "5432",
+		"/app/db/name": "mydb",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_EmptyResult(t *testing.T) {
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			return nil, &api.QueryMeta{}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/missing"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_Error(t *testing.T) {
+	expectedErr := errors.New("consul error")
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			return nil, nil, expectedErr
+		},
+	}
+
+	client := newTestClient(mock)
+
+	_, err := client.GetValues([]string{"/app"})
+	if err == nil {
+		t.Error("GetValues() expected error, got nil")
+	}
+	if err != expectedErr {
+		t.Errorf("GetValues() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestGetValues_EmptyKeys(t *testing.T) {
+	mock := &mockConsulKV{}
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_LeadingSlashHandling(t *testing.T) {
+	var capturedPrefix string
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			capturedPrefix = prefix
+			return nil, &api.QueryMeta{}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+	client.GetValues([]string{"/app/config"})
+
+	// Leading slash should be trimmed
+	if capturedPrefix != "app/config" {
+		t.Errorf("Expected prefix 'app/config', got '%s'", capturedPrefix)
+	}
+}
+
+func TestWatchPrefix_StopChannel(t *testing.T) {
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			// This should not complete before stopChan
+			return nil, &api.QueryMeta{LastIndex: 100}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+	stopChan := make(chan bool, 1)
+
+	// Send stop signal before watch can complete
+	stopChan <- true
+
+	index, err := client.WatchPrefix("/app", []string{"/app/key"}, 10, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 10 {
+		t.Errorf("WatchPrefix() index = %d, want 10 (unchanged)", index)
+	}
+}
+
+func TestWatchPrefix_NewIndex(t *testing.T) {
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			return nil, &api.QueryMeta{LastIndex: 200}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+	stopChan := make(chan bool)
+
+	index, err := client.WatchPrefix("app", []string{"/app/key"}, 100, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 200 {
+		t.Errorf("WatchPrefix() index = %d, want 200", index)
+	}
+}
+
+func TestWatchPrefix_Error(t *testing.T) {
+	expectedErr := errors.New("watch error")
+	mock := &mockConsulKV{
+		listFunc: func(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+			return nil, nil, expectedErr
+		},
+	}
+
+	client := newTestClient(mock)
+	stopChan := make(chan bool)
+
+	_, err := client.WatchPrefix("app", []string{"/app/key"}, 100, stopChan)
+	if err == nil {
+		t.Error("WatchPrefix() expected error, got nil")
+	}
+}

--- a/pkg/backends/dynamodb/client.go
+++ b/pkg/backends/dynamodb/client.go
@@ -9,10 +9,18 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
+// dynamoDBAPI defines the interface for DynamoDB operations used by this client.
+// This allows for easy mocking in tests.
+type dynamoDBAPI interface {
+	GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
+	Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error)
+	DescribeTable(input *dynamodb.DescribeTableInput) (*dynamodb.DescribeTableOutput, error)
+}
+
 // Client is a wrapper around the DynamoDB client
 // and also holds the table to lookup key value pairs from
 type Client struct {
-	client *dynamodb.DynamoDB
+	client dynamoDBAPI
 	table  string
 }
 

--- a/pkg/backends/dynamodb/client_test.go
+++ b/pkg/backends/dynamodb/client_test.go
@@ -1,0 +1,290 @@
+package dynamodb
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+// mockDynamoDB implements the dynamoDBAPI interface for testing
+type mockDynamoDB struct {
+	getItemFunc      func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
+	scanFunc         func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error)
+	describeTableFunc func(input *dynamodb.DescribeTableInput) (*dynamodb.DescribeTableOutput, error)
+}
+
+func (m *mockDynamoDB) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+	if m.getItemFunc != nil {
+		return m.getItemFunc(input)
+	}
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (m *mockDynamoDB) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+	if m.scanFunc != nil {
+		return m.scanFunc(input)
+	}
+	return &dynamodb.ScanOutput{}, nil
+}
+
+func (m *mockDynamoDB) DescribeTable(input *dynamodb.DescribeTableInput) (*dynamodb.DescribeTableOutput, error) {
+	if m.describeTableFunc != nil {
+		return m.describeTableFunc(input)
+	}
+	return &dynamodb.DescribeTableOutput{}, nil
+}
+
+// newTestClient creates a Client with a mock DynamoDB for testing
+func newTestClient(mock *mockDynamoDB, table string) *Client {
+	return &Client{
+		client: mock,
+		table:  table,
+	}
+}
+
+func TestGetValues_SingleItem(t *testing.T) {
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			key := *input.Key["key"].S
+			if key == "/test/key" {
+				return &dynamodb.GetItemOutput{
+					Item: map[string]*dynamodb.AttributeValue{
+						"key":   {S: aws.String("/test/key")},
+						"value": {S: aws.String("test_value")},
+					},
+				}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		},
+		scanFunc: func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]*dynamodb.AttributeValue{}}, nil
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.GetValues([]string{"/test/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{"/test/key": "test_value"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_PrefixScan(t *testing.T) {
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			// No exact match, return empty
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		},
+		scanFunc: func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+			// Return items that match the prefix
+			return &dynamodb.ScanOutput{
+				Items: []map[string]*dynamodb.AttributeValue{
+					{
+						"key":   {S: aws.String("/app/db/host")},
+						"value": {S: aws.String("localhost")},
+					},
+					{
+						"key":   {S: aws.String("/app/db/port")},
+						"value": {S: aws.String("5432")},
+					},
+				},
+			}, nil
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.GetValues([]string{"/app/db"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/app/db/host": "localhost",
+		"/app/db/port": "5432",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MultipleKeys(t *testing.T) {
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			key := *input.Key["key"].S
+			switch key {
+			case "/key1":
+				return &dynamodb.GetItemOutput{
+					Item: map[string]*dynamodb.AttributeValue{
+						"key":   {S: aws.String("/key1")},
+						"value": {S: aws.String("value1")},
+					},
+				}, nil
+			case "/key2":
+				return &dynamodb.GetItemOutput{
+					Item: map[string]*dynamodb.AttributeValue{
+						"key":   {S: aws.String("/key2")},
+						"value": {S: aws.String("value2")},
+					},
+				}, nil
+			}
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		},
+		scanFunc: func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]*dynamodb.AttributeValue{}}, nil
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.GetValues([]string{"/key1", "/key2"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/key1": "value1",
+		"/key2": "value2",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MissingKey(t *testing.T) {
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		},
+		scanFunc: func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]*dynamodb.AttributeValue{}}, nil
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.GetValues([]string{"/missing/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_GetItemError(t *testing.T) {
+	expectedErr := errors.New("dynamodb error")
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			return nil, expectedErr
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	_, err := client.GetValues([]string{"/test/key"})
+	if err == nil {
+		t.Error("GetValues() expected error, got nil")
+	}
+	if err != expectedErr {
+		t.Errorf("GetValues() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestGetValues_ScanError(t *testing.T) {
+	expectedErr := errors.New("scan error")
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			// No exact match
+			return &dynamodb.GetItemOutput{Item: nil}, nil
+		},
+		scanFunc: func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+			return nil, expectedErr
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	_, err := client.GetValues([]string{"/test/prefix"})
+	if err == nil {
+		t.Error("GetValues() expected error, got nil")
+	}
+	if err != expectedErr {
+		t.Errorf("GetValues() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestGetValues_NonStringValue(t *testing.T) {
+	mock := &mockDynamoDB{
+		getItemFunc: func(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
+			// Return item with non-string value (e.g., a number)
+			return &dynamodb.GetItemOutput{
+				Item: map[string]*dynamodb.AttributeValue{
+					"key":   {S: aws.String("/test/key")},
+					"value": {N: aws.String("123")}, // Number instead of string
+				},
+			}, nil
+		},
+		scanFunc: func(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]*dynamodb.AttributeValue{}}, nil
+		},
+	}
+
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.GetValues([]string{"/test/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	// Non-string values should be skipped (logged as warning)
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v (non-string values should be skipped)", result, expected)
+	}
+}
+
+func TestGetValues_EmptyKeys(t *testing.T) {
+	mock := &mockDynamoDB{}
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.GetValues([]string{})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestWatchPrefix(t *testing.T) {
+	mock := &mockDynamoDB{}
+	client := newTestClient(mock, "test-table")
+
+	stopChan := make(chan bool, 1)
+
+	// Send stop signal immediately
+	go func() {
+		stopChan <- true
+	}()
+
+	index, err := client.WatchPrefix("/test", []string{"/test/key"}, 0, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 0 {
+		t.Errorf("WatchPrefix() index = %d, want 0", index)
+	}
+}

--- a/pkg/backends/env/client_test.go
+++ b/pkg/backends/env/client_test.go
@@ -1,0 +1,198 @@
+package env
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewEnvClient(t *testing.T) {
+	client, err := NewEnvClient()
+	if err != nil {
+		t.Errorf("NewEnvClient() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("NewEnvClient() returned nil client")
+	}
+}
+
+func TestGetValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		keys     []string
+		expected map[string]string
+	}{
+		{
+			name: "single key match",
+			envVars: map[string]string{
+				"FOO": "bar",
+			},
+			keys:     []string{"/foo"},
+			expected: map[string]string{"/foo": "bar"},
+		},
+		{
+			name: "prefix match",
+			envVars: map[string]string{
+				"APP_DB_HOST": "localhost",
+				"APP_DB_PORT": "5432",
+				"OTHER_VAR":   "ignored",
+			},
+			keys: []string{"/app/db"},
+			expected: map[string]string{
+				"/app/db/host": "localhost",
+				"/app/db/port": "5432",
+			},
+		},
+		{
+			name: "multiple keys",
+			envVars: map[string]string{
+				"FOO": "foo_value",
+				"BAR": "bar_value",
+			},
+			keys: []string{"/foo", "/bar"},
+			expected: map[string]string{
+				"/foo": "foo_value",
+				"/bar": "bar_value",
+			},
+		},
+		{
+			name: "key not found",
+			envVars: map[string]string{
+				"OTHER": "value",
+			},
+			keys:     []string{"/missing"},
+			expected: map[string]string{},
+		},
+		{
+			name: "case insensitive matching",
+			envVars: map[string]string{
+				"MY_VAR": "value",
+			},
+			keys:     []string{"/my/var"},
+			expected: map[string]string{"/my/var": "value"},
+		},
+		{
+			name:     "empty keys",
+			envVars:  map[string]string{"FOO": "bar"},
+			keys:     []string{},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			client, err := NewEnvClient()
+			if err != nil {
+				t.Fatalf("NewEnvClient() error: %v", err)
+			}
+
+			result, err := client.GetValues(tt.keys)
+			if err != nil {
+				t.Errorf("GetValues(%v) unexpected error: %v", tt.keys, err)
+				return
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("GetValues(%v) = %v, want %v", tt.keys, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTransform(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple key",
+			input:    "/foo",
+			expected: "FOO",
+		},
+		{
+			name:     "nested key",
+			input:    "/foo/bar/baz",
+			expected: "FOO_BAR_BAZ",
+		},
+		{
+			name:     "already uppercase",
+			input:    "/FOO",
+			expected: "FOO",
+		},
+		{
+			name:     "no leading slash",
+			input:    "foo",
+			expected: "FOO",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := transform(tt.input)
+			if result != tt.expected {
+				t.Errorf("transform(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClean(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple key",
+			input:    "FOO",
+			expected: "/foo",
+		},
+		{
+			name:     "nested key with underscores",
+			input:    "FOO_BAR_BAZ",
+			expected: "/foo/bar/baz",
+		},
+		{
+			name:     "already lowercase",
+			input:    "foo",
+			expected: "/foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := clean(tt.input)
+			if result != tt.expected {
+				t.Errorf("clean(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWatchPrefix(t *testing.T) {
+	client, err := NewEnvClient()
+	if err != nil {
+		t.Fatalf("NewEnvClient() error: %v", err)
+	}
+
+	stopChan := make(chan bool, 1)
+
+	// Send stop signal immediately
+	go func() {
+		stopChan <- true
+	}()
+
+	index, err := client.WatchPrefix("/test", []string{"/test/key"}, 0, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 0 {
+		t.Errorf("WatchPrefix() index = %d, want 0", index)
+	}
+}

--- a/pkg/backends/etcd/client_test.go
+++ b/pkg/backends/etcd/client_test.go
@@ -1,0 +1,162 @@
+package etcd
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWatch_Update(t *testing.T) {
+	w := &Watch{
+		revision: 0,
+		cond:     make(chan struct{}),
+		rwl:      sync.RWMutex{},
+	}
+
+	// Update should set revision and close the cond channel
+	w.update(100)
+
+	if w.revision != 100 {
+		t.Errorf("Watch.revision = %d, want 100", w.revision)
+	}
+
+	// The old cond channel should be closed
+	select {
+	case <-w.cond:
+		// Expected - old cond was closed, new one created
+	default:
+		// Should not block - cond should be a new channel
+	}
+}
+
+func TestWatch_UpdateMultipleTimes(t *testing.T) {
+	w := &Watch{
+		revision: 0,
+		cond:     make(chan struct{}),
+		rwl:      sync.RWMutex{},
+	}
+
+	w.update(10)
+	w.update(20)
+	w.update(30)
+
+	if w.revision != 30 {
+		t.Errorf("Watch.revision = %d, want 30", w.revision)
+	}
+}
+
+func TestWatch_WaitNext_AlreadyUpdated(t *testing.T) {
+	w := &Watch{
+		revision: 100,
+		cond:     make(chan struct{}),
+		rwl:      sync.RWMutex{},
+	}
+
+	notify := make(chan int64, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// WaitNext should return immediately since revision (100) > lastRevision (50)
+	go w.WaitNext(ctx, 50, notify)
+
+	select {
+	case rev := <-notify:
+		if rev != 100 {
+			t.Errorf("WaitNext returned revision %d, want 100", rev)
+		}
+	case <-ctx.Done():
+		t.Error("WaitNext timed out when it should have returned immediately")
+	}
+}
+
+func TestWatch_WaitNext_WaitsForUpdate(t *testing.T) {
+	w := &Watch{
+		revision: 50,
+		cond:     make(chan struct{}),
+		rwl:      sync.RWMutex{},
+	}
+
+	notify := make(chan int64, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// WaitNext should wait since revision (50) is not > lastRevision (50)
+	go w.WaitNext(ctx, 50, notify)
+
+	// Give goroutine time to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Now update
+	w.update(100)
+
+	select {
+	case rev := <-notify:
+		if rev != 100 {
+			t.Errorf("WaitNext returned revision %d, want 100", rev)
+		}
+	case <-ctx.Done():
+		t.Error("WaitNext timed out waiting for update")
+	}
+}
+
+func TestWatch_WaitNext_Cancelled(t *testing.T) {
+	w := &Watch{
+		revision: 50,
+		cond:     make(chan struct{}),
+		rwl:      sync.RWMutex{},
+	}
+
+	notify := make(chan int64, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// WaitNext should wait since revision (50) is not > lastRevision (50)
+	go w.WaitNext(ctx, 50, notify)
+
+	// Give goroutine time to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Give goroutine time to exit
+	time.Sleep(10 * time.Millisecond)
+
+	select {
+	case <-notify:
+		t.Error("WaitNext should not send on notify when cancelled")
+	default:
+		// Expected - no notification sent
+	}
+}
+
+func TestWatch_ConcurrentAccess(t *testing.T) {
+	w := &Watch{
+		revision: 0,
+		cond:     make(chan struct{}),
+		rwl:      sync.RWMutex{},
+	}
+
+	// Start multiple goroutines updating and reading
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(rev int64) {
+			defer wg.Done()
+			w.update(rev)
+		}(int64(i * 10))
+	}
+
+	wg.Wait()
+
+	// Revision should be set (exact value depends on goroutine scheduling)
+	if w.revision < 0 || w.revision > 90 {
+		t.Errorf("Watch.revision = %d, expected between 0 and 90", w.revision)
+	}
+}
+
+// Note: Full GetValues and WatchPrefix tests require a running etcd instance.
+// These are covered by integration tests in .github/workflows/integration-tests.yml
+//
+// The etcd client uses complex transaction batching and watch management
+// that requires an actual etcd connection to test properly.

--- a/pkg/backends/file/client_test.go
+++ b/pkg/backends/file/client_test.go
@@ -1,0 +1,496 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestNewFileClient(t *testing.T) {
+	paths := []string{"/path/to/file.yaml"}
+	filter := "*.yaml"
+
+	client, err := NewFileClient(paths, filter)
+	if err != nil {
+		t.Fatalf("NewFileClient() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("NewFileClient() returned nil client")
+	}
+	if !reflect.DeepEqual(client.filepath, paths) {
+		t.Errorf("client.filepath = %v, want %v", client.filepath, paths)
+	}
+	if client.filter != filter {
+		t.Errorf("client.filter = %s, want %s", client.filter, filter)
+	}
+}
+
+func TestGetValues_YAMLFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+database:
+  host: localhost
+  port: "5432"
+  name: mydb
+app:
+  debug: true
+  timeout: 30
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{"/database"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/database/host": "localhost",
+		"/database/port": "5432",
+		"/database/name": "mydb",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_JSONFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	jsonFile := filepath.Join(tmpDir, "config.json")
+
+	jsonContent := `{
+	"server": {
+		"host": "0.0.0.0",
+		"port": 8080
+	},
+	"logging": {
+		"level": "info"
+	}
+}`
+	if err := os.WriteFile(jsonFile, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write JSON file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{jsonFile}, "")
+
+	result, err := client.GetValues([]string{"/server"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/server/host": "0.0.0.0",
+		"/server/port": "8080",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MultipleKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+database:
+  host: localhost
+cache:
+  host: redis
+other:
+  value: ignored
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{"/database", "/cache"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/database/host": "localhost",
+		"/cache/host":    "redis",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_NestedStructure(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+app:
+  db:
+    primary:
+      host: primary-db
+    replica:
+      host: replica-db
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{"/app/db"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/app/db/primary/host": "primary-db",
+		"/app/db/replica/host": "replica-db",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_ArrayValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+servers:
+  - host: server1
+  - host: server2
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{"/servers"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/servers/0/host": "server1",
+		"/servers/1/host": "server2",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_DifferentTypes(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+values:
+  string_val: hello
+  int_val: 42
+  float_val: 3.14
+  bool_val: true
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{"/values"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/values/string_val": "hello",
+		"/values/int_val":    "42",
+		"/values/float_val":  "3.14",
+		"/values/bool_val":   "true",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := filepath.Join(tmpDir, "file1.yaml")
+	file2 := filepath.Join(tmpDir, "file2.yaml")
+
+	yaml1 := `
+db:
+  host: localhost
+`
+	yaml2 := `
+cache:
+  host: redis
+`
+	if err := os.WriteFile(file1, []byte(yaml1), 0644); err != nil {
+		t.Fatalf("Failed to write file1: %v", err)
+	}
+	if err := os.WriteFile(file2, []byte(yaml2), 0644); err != nil {
+		t.Fatalf("Failed to write file2: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{file1, file2}, "")
+
+	result, err := client.GetValues([]string{"/db", "/cache"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/db/host":    "localhost",
+		"/cache/host": "redis",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_DirectoryWithFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+	jsonFile := filepath.Join(tmpDir, "other.json")
+
+	yamlContent := `
+yaml_key: yaml_value
+`
+	jsonContent := `{"json_key": "json_value"}`
+
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+	if err := os.WriteFile(jsonFile, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("Failed to write JSON file: %v", err)
+	}
+
+	// Only get yaml files
+	client, _ := NewFileClient([]string{tmpDir}, "*.yaml")
+
+	result, err := client.GetValues([]string{"/"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	// Should only contain YAML file content
+	if _, ok := result["/yaml_key"]; !ok {
+		t.Error("Expected /yaml_key to be present")
+	}
+	if _, ok := result["/json_key"]; ok {
+		t.Error("Expected /json_key to NOT be present (filtered out)")
+	}
+}
+
+func TestGetValues_MissingFile(t *testing.T) {
+	client, _ := NewFileClient([]string{"/nonexistent/file.yaml"}, "")
+
+	_, err := client.GetValues([]string{"/key"})
+	if err == nil {
+		t.Error("GetValues() expected error for missing file, got nil")
+	}
+}
+
+func TestGetValues_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "invalid.yaml")
+
+	// Invalid YAML content
+	invalidContent := `
+key: value
+  bad indentation: error
+`
+	if err := os.WriteFile(yamlFile, []byte(invalidContent), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	_, err := client.GetValues([]string{"/key"})
+	if err == nil {
+		t.Error("GetValues() expected error for invalid YAML, got nil")
+	}
+}
+
+func TestGetValues_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	jsonFile := filepath.Join(tmpDir, "invalid.json")
+
+	// Invalid JSON content
+	invalidContent := `{key: "missing quotes"}`
+	if err := os.WriteFile(jsonFile, []byte(invalidContent), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{jsonFile}, "")
+
+	_, err := client.GetValues([]string{"/key"})
+	if err == nil {
+		t.Error("GetValues() expected error for invalid JSON, got nil")
+	}
+}
+
+func TestGetValues_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "empty.yaml")
+
+	if err := os.WriteFile(yamlFile, []byte(""), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{"/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_EmptyKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+key: value
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+
+	result, err := client.GetValues([]string{})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	// With empty keys, nothing should match
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestWatchPrefix_InitialCall(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	if err := os.WriteFile(yamlFile, []byte("key: value"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+	stopChan := make(chan bool)
+
+	// waitIndex 0 should return immediately with 1
+	index, err := client.WatchPrefix("/", []string{"/key"}, 0, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 1 {
+		t.Errorf("WatchPrefix() index = %d, want 1", index)
+	}
+}
+
+func TestWatchPrefix_StopChannel(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	if err := os.WriteFile(yamlFile, []byte("key: value"), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+	stopChan := make(chan bool, 1)
+
+	// Send stop signal
+	go func() {
+		stopChan <- true
+	}()
+
+	index, err := client.WatchPrefix("/", []string{"/key"}, 1, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 1 {
+		t.Errorf("WatchPrefix() index = %d, want 1", index)
+	}
+}
+
+func TestNodeWalk(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     interface{}
+		key      string
+		expected map[string]string
+	}{
+		{
+			name:     "string value",
+			node:     "hello",
+			key:      "/test",
+			expected: map[string]string{"/test": "hello"},
+		},
+		{
+			name:     "int value",
+			node:     42,
+			key:      "/num",
+			expected: map[string]string{"/num": "42"},
+		},
+		{
+			name:     "bool value",
+			node:     true,
+			key:      "/flag",
+			expected: map[string]string{"/flag": "true"},
+		},
+		{
+			name:     "float value",
+			node:     3.14159,
+			key:      "/pi",
+			expected: map[string]string{"/pi": "3.14159"},
+		},
+		{
+			name: "map[string]interface{}",
+			node: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			key: "/root",
+			expected: map[string]string{
+				"/root/key1": "value1",
+				"/root/key2": "value2",
+			},
+		},
+		{
+			name: "slice",
+			node: []interface{}{"a", "b", "c"},
+			key:  "/items",
+			expected: map[string]string{
+				"/items/0": "a",
+				"/items/1": "b",
+				"/items/2": "c",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := make(map[string]string)
+			nodeWalk(tt.node, tt.key, vars)
+			if !reflect.DeepEqual(vars, tt.expected) {
+				t.Errorf("nodeWalk() vars = %v, want %v", vars, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/backends/redis/client_test.go
+++ b/pkg/backends/redis/client_test.go
@@ -1,0 +1,119 @@
+package redis
+
+import (
+	"testing"
+)
+
+func TestTransform(t *testing.T) {
+	tests := []struct {
+		name      string
+		separator string
+		input     string
+		expected  string
+	}{
+		{
+			name:      "default separator (no change)",
+			separator: "/",
+			input:     "/app/config/key",
+			expected:  "/app/config/key",
+		},
+		{
+			name:      "colon separator",
+			separator: ":",
+			input:     "/app/config/key",
+			expected:  "app:config:key",
+		},
+		{
+			name:      "dot separator",
+			separator: ".",
+			input:     "/db/host",
+			expected:  "db.host",
+		},
+		{
+			name:      "underscore separator",
+			separator: "_",
+			input:     "/service/name",
+			expected:  "service_name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{separator: tt.separator}
+			result := client.transform(tt.input)
+			if result != tt.expected {
+				t.Errorf("transform(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClean(t *testing.T) {
+	tests := []struct {
+		name      string
+		separator string
+		input     string
+		expected  string
+	}{
+		{
+			name:      "default separator (no change)",
+			separator: "/",
+			input:     "/app/config/key",
+			expected:  "/app/config/key",
+		},
+		{
+			name:      "colon separator to slash",
+			separator: ":",
+			input:     "app:config:key",
+			expected:  "/app/config/key",
+		},
+		{
+			name:      "add leading slash",
+			separator: "/",
+			input:     "app/config",
+			expected:  "/app/config",
+		},
+		{
+			name:      "dot separator to slash",
+			separator: ".",
+			input:     "db.host.name",
+			expected:  "/db/host/name",
+		},
+		{
+			name:      "already has leading slash with colon",
+			separator: ":",
+			input:     "/app:config",
+			expected:  "/app/config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{separator: tt.separator}
+			result := client.clean(tt.input)
+			if result != tt.expected {
+				t.Errorf("clean(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWatchPrefix_InitialCall(t *testing.T) {
+	client := &Client{
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	// waitIndex 0 should return immediately with 1
+	index, err := client.WatchPrefix("/app", []string{"/app/key"}, 0, nil)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 1 {
+		t.Errorf("WatchPrefix() index = %d, want 1", index)
+	}
+}
+
+// Note: Full GetValues and WatchPrefix tests require a running Redis instance
+// or significant refactoring to support mocking. These are covered by
+// integration tests in .github/workflows/integration-tests.yml

--- a/pkg/backends/ssm/client.go
+++ b/pkg/backends/ssm/client.go
@@ -12,8 +12,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
+// ssmAPI defines the interface for SSM operations used by this client.
+// This allows for easy mocking in tests.
+type ssmAPI interface {
+	GetParameter(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+	GetParametersByPathPages(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error
+}
+
 type Client struct {
-	client *ssm.SSM
+	client ssmAPI
 }
 
 func New() (*Client, error) {

--- a/pkg/backends/ssm/client_test.go
+++ b/pkg/backends/ssm/client_test.go
@@ -1,0 +1,304 @@
+package ssm
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+// mockSSM implements the ssmAPI interface for testing
+type mockSSM struct {
+	getParameterFunc          func(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+	getParametersByPathPagesFunc func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error
+}
+
+func (m *mockSSM) GetParameter(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+	if m.getParameterFunc != nil {
+		return m.getParameterFunc(input)
+	}
+	return &ssm.GetParameterOutput{}, nil
+}
+
+func (m *mockSSM) GetParametersByPathPages(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+	if m.getParametersByPathPagesFunc != nil {
+		return m.getParametersByPathPagesFunc(input, fn)
+	}
+	return nil
+}
+
+// newTestClient creates a Client with a mock SSM for testing
+func newTestClient(mock *mockSSM) *Client {
+	return &Client{
+		client: mock,
+	}
+}
+
+func TestGetValues_SingleParameter(t *testing.T) {
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			// No results from path search
+			fn(&ssm.GetParametersByPathOutput{Parameters: []*ssm.Parameter{}}, true)
+			return nil
+		},
+		getParameterFunc: func(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			if *input.Name == "/app/config/key" {
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String("/app/config/key"),
+						Value: aws.String("test_value"),
+					},
+				}, nil
+			}
+			return nil, awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil)
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/app/config/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{"/app/config/key": "test_value"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_ParametersByPath(t *testing.T) {
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			if *input.Path == "/app/db" {
+				fn(&ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{Name: aws.String("/app/db/host"), Value: aws.String("localhost")},
+						{Name: aws.String("/app/db/port"), Value: aws.String("5432")},
+					},
+				}, true)
+			}
+			return nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/app/db"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/app/db/host": "localhost",
+		"/app/db/port": "5432",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_PaginatedResults(t *testing.T) {
+	callCount := 0
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			// Simulate pagination - first page
+			fn(&ssm.GetParametersByPathOutput{
+				Parameters: []*ssm.Parameter{
+					{Name: aws.String("/app/page1/key1"), Value: aws.String("value1")},
+				},
+			}, false)
+			callCount++
+
+			// Second page (last)
+			fn(&ssm.GetParametersByPathOutput{
+				Parameters: []*ssm.Parameter{
+					{Name: aws.String("/app/page1/key2"), Value: aws.String("value2")},
+				},
+			}, true)
+			callCount++
+			return nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/app/page1"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/app/page1/key1": "value1",
+		"/app/page1/key2": "value2",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_MultipleKeys(t *testing.T) {
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			path := *input.Path
+			switch path {
+			case "/key1":
+				fn(&ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{Name: aws.String("/key1/sub"), Value: aws.String("value1")},
+					},
+				}, true)
+			case "/key2":
+				fn(&ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{Name: aws.String("/key2/sub"), Value: aws.String("value2")},
+					},
+				}, true)
+			default:
+				fn(&ssm.GetParametersByPathOutput{Parameters: []*ssm.Parameter{}}, true)
+			}
+			return nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/key1", "/key2"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/key1/sub": "value1",
+		"/key2/sub": "value2",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_ParameterNotFound(t *testing.T) {
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			// No results from path search
+			fn(&ssm.GetParametersByPathOutput{Parameters: []*ssm.Parameter{}}, true)
+			return nil
+		},
+		getParameterFunc: func(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return nil, awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil)
+		},
+	}
+
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{"/missing/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_PathError(t *testing.T) {
+	expectedErr := awserr.New("InternalServerError", "internal error", nil)
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			return expectedErr
+		},
+	}
+
+	client := newTestClient(mock)
+
+	_, err := client.GetValues([]string{"/app/config"})
+	if err == nil {
+		t.Error("GetValues() expected error, got nil")
+	}
+}
+
+func TestGetValues_GetParameterError(t *testing.T) {
+	expectedErr := awserr.New("AccessDeniedException", "access denied", nil)
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			// No results from path search
+			fn(&ssm.GetParametersByPathOutput{Parameters: []*ssm.Parameter{}}, true)
+			return nil
+		},
+		getParameterFunc: func(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return nil, expectedErr
+		},
+	}
+
+	client := newTestClient(mock)
+
+	_, err := client.GetValues([]string{"/app/config"})
+	if err == nil {
+		t.Error("GetValues() expected error, got nil")
+	}
+}
+
+func TestGetValues_EmptyKeys(t *testing.T) {
+	mock := &mockSSM{}
+	client := newTestClient(mock)
+
+	result, err := client.GetValues([]string{})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestGetValues_RecursiveEnabled(t *testing.T) {
+	var capturedInput *ssm.GetParametersByPathInput
+	mock := &mockSSM{
+		getParametersByPathPagesFunc: func(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error {
+			capturedInput = input
+			fn(&ssm.GetParametersByPathOutput{Parameters: []*ssm.Parameter{}}, true)
+			return nil
+		},
+		getParameterFunc: func(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return nil, awserr.New(ssm.ErrCodeParameterNotFound, "not found", nil)
+		},
+	}
+
+	client := newTestClient(mock)
+	client.GetValues([]string{"/app"})
+
+	if capturedInput == nil {
+		t.Fatal("GetParametersByPathPages was not called")
+	}
+	if !*capturedInput.Recursive {
+		t.Error("Recursive should be true")
+	}
+	if !*capturedInput.WithDecryption {
+		t.Error("WithDecryption should be true")
+	}
+}
+
+func TestWatchPrefix(t *testing.T) {
+	mock := &mockSSM{}
+	client := newTestClient(mock)
+
+	stopChan := make(chan bool, 1)
+
+	// Send stop signal immediately
+	go func() {
+		stopChan <- true
+	}()
+
+	index, err := client.WatchPrefix("/test", []string{"/test/key"}, 0, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 0 {
+		t.Errorf("WatchPrefix() index = %d, want 0", index)
+	}
+}

--- a/pkg/backends/vault/client_test.go
+++ b/pkg/backends/vault/client_test.go
@@ -1,0 +1,230 @@
+package vault
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetMount(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "simple path",
+			path:     "/secret/data/app",
+			expected: "/secret",
+		},
+		{
+			name:     "nested path",
+			path:     "/kv/data/config/database",
+			expected: "/kv",
+		},
+		{
+			name:     "root path",
+			path:     "/secret",
+			expected: "/secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getMount(tt.path)
+			if result != tt.expected {
+				t.Errorf("getMount(%s) = %s, want %s", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUniqMounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "no duplicates",
+			input:    []string{"/secret", "/kv", "/database"},
+			expected: []string{"/secret", "/kv", "/database"},
+		},
+		{
+			name:     "with duplicates",
+			input:    []string{"/secret", "/kv", "/secret", "/kv", "/database"},
+			expected: []string{"/secret", "/kv", "/database"},
+		},
+		{
+			name:     "all duplicates",
+			input:    []string{"/secret", "/secret", "/secret"},
+			expected: []string{"/secret"},
+		},
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := uniqMounts(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("uniqMounts(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		value    interface{}
+		mount    string
+		expected map[string]string
+	}{
+		{
+			name:     "string value",
+			key:      "/secret/key",
+			value:    "value123",
+			mount:    "/secret",
+			expected: map[string]string{"/secret/key": "value123"},
+		},
+		{
+			name:  "nested map",
+			key:   "/secret/config",
+			value: map[string]interface{}{"db_host": "localhost", "db_port": "5432"},
+			mount: "/secret",
+			expected: map[string]string{
+				"/secret/config/db_host": "localhost",
+				"/secret/config/db_port": "5432",
+			},
+		},
+		{
+			name:  "deeply nested map",
+			key:   "/secret/app",
+			value: map[string]interface{}{"database": map[string]interface{}{"host": "localhost"}},
+			mount: "/secret",
+			expected: map[string]string{
+				"/secret/app/database/host": "localhost",
+			},
+		},
+		{
+			name:     "removes data/ from key",
+			key:      "/secret/data/config",
+			value:    "value",
+			mount:    "/secret",
+			expected: map[string]string{"/secret/config": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := make(map[string]string)
+			flatten(tt.key, tt.value, tt.mount, vars)
+			if !reflect.DeepEqual(vars, tt.expected) {
+				t.Errorf("flatten() vars = %v, want %v", vars, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetParameter_Success(t *testing.T) {
+	params := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	result := getParameter("key1", params)
+	if result != "value1" {
+		t.Errorf("getParameter() = %s, want value1", result)
+	}
+}
+
+func TestGetParameter_Missing(t *testing.T) {
+	params := map[string]string{}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("getParameter() expected panic for missing key")
+		}
+	}()
+
+	getParameter("missing", params)
+}
+
+func TestPanicToError_StringPanic(t *testing.T) {
+	var err error
+
+	func() {
+		defer panicToError(&err)
+		panic("test error")
+	}()
+
+	if err == nil {
+		t.Error("panicToError() expected error, got nil")
+	}
+	if err.Error() != "test error" {
+		t.Errorf("panicToError() error = %v, want 'test error'", err)
+	}
+}
+
+func TestPanicToError_ErrorPanic(t *testing.T) {
+	var err error
+	expectedErr := &testError{msg: "test error"}
+
+	func() {
+		defer panicToError(&err)
+		panic(expectedErr)
+	}()
+
+	if err != expectedErr {
+		t.Errorf("panicToError() error = %v, want %v", err, expectedErr)
+	}
+}
+
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
+}
+
+func TestPanicToError_NoPanic(t *testing.T) {
+	var err error
+
+	func() {
+		defer panicToError(&err)
+		// No panic
+	}()
+
+	if err != nil {
+		t.Errorf("panicToError() error = %v, want nil", err)
+	}
+}
+
+func TestWatchPrefix(t *testing.T) {
+	client := &Client{client: nil}
+	stopChan := make(chan bool, 1)
+
+	// Send stop signal immediately
+	go func() {
+		stopChan <- true
+	}()
+
+	index, err := client.WatchPrefix("/secret", []string{"/secret/key"}, 0, stopChan)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 0 {
+		t.Errorf("WatchPrefix() index = %d, want 0", index)
+	}
+}
+
+// Note: Full GetValues and authentication tests require a running Vault instance.
+// These are covered by integration tests in .github/workflows/integration-tests.yml
+//
+// The Vault client has complex authentication flows (app-role, github, kubernetes, etc.)
+// that require an actual Vault server to test properly.

--- a/pkg/backends/zookeeper/client_test.go
+++ b/pkg/backends/zookeeper/client_test.go
@@ -1,0 +1,27 @@
+package zookeeper
+
+import (
+	"testing"
+)
+
+func TestWatchPrefix_InitialCall(t *testing.T) {
+	// Create a client with nil connection - WatchPrefix with waitIndex=0
+	// should return immediately without using the connection
+	client := &Client{client: nil}
+
+	// waitIndex 0 should return immediately with 1
+	index, err := client.WatchPrefix("/app", []string{"/app/key"}, 0, nil)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 1 {
+		t.Errorf("WatchPrefix() index = %d, want 1", index)
+	}
+}
+
+// Note: Full GetValues and WatchPrefix tests require a running Zookeeper instance.
+// These are covered by integration tests in .github/workflows/integration-tests.yml
+//
+// Testing the nodeWalk function and GetValues would require mocking the zk.Conn
+// interface, which is complex due to the number of methods involved.
+// Consider using docker-based integration tests for comprehensive coverage.

--- a/pkg/template/processor_test.go
+++ b/pkg/template/processor_test.go
@@ -1,0 +1,102 @@
+package template
+
+import (
+	"testing"
+)
+
+func TestIntervalProcessor_Creation(t *testing.T) {
+	config := Config{}
+	stopChan := make(chan bool)
+	doneChan := make(chan bool)
+	errChan := make(chan error)
+	interval := 10
+
+	processor := IntervalProcessor(config, stopChan, doneChan, errChan, interval)
+	if processor == nil {
+		t.Error("IntervalProcessor() returned nil")
+	}
+
+	// Verify it's the right type
+	_, ok := processor.(*intervalProcessor)
+	if !ok {
+		t.Error("IntervalProcessor() did not return *intervalProcessor")
+	}
+}
+
+func TestWatchProcessor_Creation(t *testing.T) {
+	config := Config{}
+	stopChan := make(chan bool)
+	doneChan := make(chan bool)
+	errChan := make(chan error)
+
+	processor := WatchProcessor(config, stopChan, doneChan, errChan)
+	if processor == nil {
+		t.Error("WatchProcessor() returned nil")
+	}
+
+	// Verify it's the right type
+	_, ok := processor.(*watchProcessor)
+	if !ok {
+		t.Error("WatchProcessor() did not return *watchProcessor")
+	}
+}
+
+func TestProcess_EmptyTemplateResources(t *testing.T) {
+	// Test that process with empty slice doesn't error
+	err := process([]*TemplateResource{})
+	if err != nil {
+		t.Errorf("process([]) unexpected error: %v", err)
+	}
+}
+
+func TestProcess_NilTemplateResources(t *testing.T) {
+	// Test that process with nil slice doesn't error
+	err := process(nil)
+	if err != nil {
+		t.Errorf("process(nil) unexpected error: %v", err)
+	}
+}
+
+func TestGetTemplateResources_NonExistentConfDir(t *testing.T) {
+	config := Config{
+		ConfDir:   "/nonexistent/path",
+		ConfigDir: "/nonexistent/path/conf.d",
+	}
+
+	templates, err := getTemplateResources(config)
+	// Should return nil, nil when confdir doesn't exist (logs warning)
+	if err != nil {
+		t.Errorf("getTemplateResources() unexpected error: %v", err)
+	}
+	if templates != nil {
+		t.Errorf("getTemplateResources() = %v, want nil", templates)
+	}
+}
+
+func TestGetTemplateResources_EmptyConfigDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	config := Config{
+		ConfDir:   tmpDir,
+		ConfigDir: tmpDir,
+	}
+
+	templates, err := getTemplateResources(config)
+	if err != nil {
+		t.Errorf("getTemplateResources() unexpected error: %v", err)
+	}
+	if len(templates) != 0 {
+		t.Errorf("getTemplateResources() returned %d templates, want 0", len(templates))
+	}
+}
+
+// Note: Full processor tests require setting up template resources with
+// actual backend connections. These are covered by integration tests.
+//
+// The intervalProcessor and watchProcessor Process() methods are difficult
+// to unit test because they:
+// 1. Call getTemplateResources which reads from disk
+// 2. Create actual connections to backends
+// 3. Run in infinite loops until stopped
+//
+// Consider using dependency injection for more comprehensive unit testing.

--- a/pkg/template/template_funcs_test.go
+++ b/pkg/template/template_funcs_test.go
@@ -1,0 +1,504 @@
+package template
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kelseyhightower/memkv"
+)
+
+func TestSeq(t *testing.T) {
+	tests := []struct {
+		name     string
+		first    int
+		last     int
+		expected []int
+	}{
+		{
+			name:     "ascending sequence",
+			first:    1,
+			last:     5,
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "single element",
+			first:    3,
+			last:     3,
+			expected: []int{3},
+		},
+		{
+			name:     "negative to positive",
+			first:    -2,
+			last:     2,
+			expected: []int{-2, -1, 0, 1, 2},
+		},
+		{
+			name:     "empty when first > last",
+			first:    5,
+			last:     1,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Seq(tt.first, tt.last)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Seq(%d, %d) = %v, want %v", tt.first, tt.last, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSortByLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "sort strings by length",
+			input:    []string{"aaa", "a", "aa"},
+			expected: []string{"a", "aa", "aaa"},
+		},
+		{
+			name:     "already sorted",
+			input:    []string{"x", "xx", "xxx"},
+			expected: []string{"x", "xx", "xxx"},
+		},
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "single element",
+			input:    []string{"hello"},
+			expected: []string{"hello"},
+		},
+		{
+			name:     "same length elements",
+			input:    []string{"abc", "def", "ghi"},
+			expected: []string{"abc", "def", "ghi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy to avoid modifying test data
+			input := make([]string, len(tt.input))
+			copy(input, tt.input)
+			result := SortByLength(input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SortByLength(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSortKVByLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []memkv.KVPair
+		expected []memkv.KVPair
+	}{
+		{
+			name: "sort KV pairs by key length",
+			input: []memkv.KVPair{
+				{Key: "/long/key", Value: "v1"},
+				{Key: "/k", Value: "v2"},
+				{Key: "/med", Value: "v3"},
+			},
+			expected: []memkv.KVPair{
+				{Key: "/k", Value: "v2"},
+				{Key: "/med", Value: "v3"},
+				{Key: "/long/key", Value: "v1"},
+			},
+		},
+		{
+			name:     "empty slice",
+			input:    []memkv.KVPair{},
+			expected: []memkv.KVPair{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := make([]memkv.KVPair, len(tt.input))
+			copy(input, tt.input)
+			result := SortKVByLength(input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SortKVByLength() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReverse(t *testing.T) {
+	t.Run("reverse string slice", func(t *testing.T) {
+		input := []string{"a", "b", "c", "d"}
+		expected := []string{"d", "c", "b", "a"}
+		result := Reverse(input).([]string)
+		if !reflect.DeepEqual(result, expected) {
+			t.Errorf("Reverse(%v) = %v, want %v", input, result, expected)
+		}
+	})
+
+	t.Run("reverse KVPair slice", func(t *testing.T) {
+		input := []memkv.KVPair{
+			{Key: "/a", Value: "1"},
+			{Key: "/b", Value: "2"},
+			{Key: "/c", Value: "3"},
+		}
+		expected := []memkv.KVPair{
+			{Key: "/c", Value: "3"},
+			{Key: "/b", Value: "2"},
+			{Key: "/a", Value: "1"},
+		}
+		result := Reverse(input).([]memkv.KVPair)
+		if !reflect.DeepEqual(result, expected) {
+			t.Errorf("Reverse() = %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("reverse empty slice", func(t *testing.T) {
+		input := []string{}
+		result := Reverse(input).([]string)
+		if len(result) != 0 {
+			t.Errorf("Reverse([]) should return empty slice, got %v", result)
+		}
+	})
+
+	t.Run("reverse single element", func(t *testing.T) {
+		input := []string{"only"}
+		expected := []string{"only"}
+		result := Reverse(input).([]string)
+		if !reflect.DeepEqual(result, expected) {
+			t.Errorf("Reverse(%v) = %v, want %v", input, result, expected)
+		}
+	})
+}
+
+func TestGetenv(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          string
+		defaultValue []string
+		envValue     string
+		setEnv       bool
+		expected     string
+	}{
+		{
+			name:         "env var exists",
+			key:          "TEST_GETENV_EXISTS",
+			defaultValue: []string{"default"},
+			envValue:     "actual_value",
+			setEnv:       true,
+			expected:     "actual_value",
+		},
+		{
+			name:         "env var not set with default",
+			key:          "TEST_GETENV_MISSING",
+			defaultValue: []string{"default_value"},
+			envValue:     "",
+			setEnv:       false,
+			expected:     "default_value",
+		},
+		{
+			name:         "env var not set without default",
+			key:          "TEST_GETENV_NO_DEFAULT",
+			defaultValue: []string{},
+			envValue:     "",
+			setEnv:       false,
+			expected:     "",
+		},
+		{
+			name:         "env var empty with default",
+			key:          "TEST_GETENV_EMPTY",
+			defaultValue: []string{"fallback"},
+			envValue:     "",
+			setEnv:       true,
+			expected:     "fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(tt.key, tt.envValue)
+			}
+			result := Getenv(tt.key, tt.defaultValue...)
+			if result != tt.expected {
+				t.Errorf("Getenv(%s, %v) = %s, want %s", tt.key, tt.defaultValue, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		values      []interface{}
+		expected    map[string]interface{}
+		expectError bool
+	}{
+		{
+			name:     "valid map creation",
+			values:   []interface{}{"key1", "value1", "key2", 42},
+			expected: map[string]interface{}{"key1": "value1", "key2": 42},
+		},
+		{
+			name:     "empty map",
+			values:   []interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name:        "odd number of arguments",
+			values:      []interface{}{"key1", "value1", "key2"},
+			expectError: true,
+		},
+		{
+			name:        "non-string key",
+			values:      []interface{}{123, "value1"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := CreateMap(tt.values...)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("CreateMap(%v) expected error, got nil", tt.values)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("CreateMap(%v) unexpected error: %v", tt.values, err)
+				return
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("CreateMap(%v) = %v, want %v", tt.values, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJsonObject(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        string
+		expected    map[string]interface{}
+		expectError bool
+	}{
+		{
+			name:     "valid JSON object",
+			data:     `{"key": "value", "number": 42}`,
+			expected: map[string]interface{}{"key": "value", "number": float64(42)},
+		},
+		{
+			name:     "empty object",
+			data:     `{}`,
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "nested object",
+			data:     `{"outer": {"inner": "value"}}`,
+			expected: map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+		},
+		{
+			name:        "invalid JSON",
+			data:        `{invalid}`,
+			expectError: true,
+		},
+		{
+			name:        "JSON array instead of object",
+			data:        `[1, 2, 3]`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := UnmarshalJsonObject(tt.data)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("UnmarshalJsonObject(%s) expected error, got nil", tt.data)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("UnmarshalJsonObject(%s) unexpected error: %v", tt.data, err)
+				return
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("UnmarshalJsonObject(%s) = %v, want %v", tt.data, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJsonArray(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        string
+		expected    []interface{}
+		expectError bool
+	}{
+		{
+			name:     "valid JSON array",
+			data:     `[1, 2, 3]`,
+			expected: []interface{}{float64(1), float64(2), float64(3)},
+		},
+		{
+			name:     "empty array",
+			data:     `[]`,
+			expected: []interface{}{},
+		},
+		{
+			name:     "mixed types array",
+			data:     `["string", 42, true, null]`,
+			expected: []interface{}{"string", float64(42), true, nil},
+		},
+		{
+			name:        "invalid JSON",
+			data:        `[invalid]`,
+			expectError: true,
+		},
+		{
+			name:        "JSON object instead of array",
+			data:        `{"key": "value"}`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := UnmarshalJsonArray(tt.data)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("UnmarshalJsonArray(%s) expected error, got nil", tt.data)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("UnmarshalJsonArray(%s) unexpected error: %v", tt.data, err)
+				return
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("UnmarshalJsonArray(%s) = %v, want %v", tt.data, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBase64Encode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "encode simple string",
+			input:    "hello",
+			expected: "aGVsbG8=",
+		},
+		{
+			name:     "encode empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "encode with special characters",
+			input:    "hello world!",
+			expected: "aGVsbG8gd29ybGQh",
+		},
+		{
+			name:     "encode unicode",
+			input:    "hello 世界",
+			expected: "aGVsbG8g5LiW55WM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Base64Encode(tt.input)
+			if result != tt.expected {
+				t.Errorf("Base64Encode(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBase64Decode(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "decode simple string",
+			input:    "aGVsbG8=",
+			expected: "hello",
+		},
+		{
+			name:     "decode empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "decode with special characters",
+			input:    "aGVsbG8gd29ybGQh",
+			expected: "hello world!",
+		},
+		{
+			name:        "invalid base64",
+			input:       "not-valid-base64!!!",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Base64Decode(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Base64Decode(%s) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Base64Decode(%s) unexpected error: %v", tt.input, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("Base64Decode(%s) = %s, want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBase64RoundTrip(t *testing.T) {
+	testStrings := []string{
+		"hello world",
+		"",
+		"special chars: !@#$%^&*()",
+		"unicode: 日本語",
+		"newlines\nand\ttabs",
+	}
+
+	for _, s := range testStrings {
+		t.Run(s, func(t *testing.T) {
+			encoded := Base64Encode(s)
+			decoded, err := Base64Decode(encoded)
+			if err != nil {
+				t.Errorf("Base64Decode(Base64Encode(%q)) error: %v", s, err)
+				return
+			}
+			if decoded != s {
+				t.Errorf("Base64 round trip failed: got %q, want %q", decoded, s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for all backend implementations (DynamoDB, SSM, Consul, env, file, Redis, Etcd, Zookeeper, Vault)
- Add tests for template functions and processor
- Refactor DynamoDB, SSM, and Consul backends to use interfaces for testability
- Increase overall test coverage from 13% to 40.2%

## Coverage Results

| Package | Coverage |
|---------|----------|
| backends/env | **100%** |
| backends/file | **83%** |
| backends/dynamodb | **61%** |
| backends/ssm | **61.5%** |
| backends/consul | **57.1%** |
| template | **57%** |
| backends (factory) | **43.5%** |
| backends/vault | 16.7% |
| backends/etcd | 12.1% |
| backends/redis | 6.9% |
| backends/zookeeper | 2.5% |

## Changes
- 12 new test files added
- 3 source files modified (added interfaces for mocking)
- 2,839 lines added

## Test plan
- [x] All unit tests pass (`go test ./pkg/...`)
- [x] Tests run with race detector (`-race`)
- [x] Coverage measured with `-coverprofile`
- [ ] Integration tests (require running backend services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)