### PR TITLE
test: Improve Redis and Etcd test coverage

### DIFF
--- a/pkg/backends/redis/client.go
+++ b/pkg/backends/redis/client.go
@@ -11,6 +11,13 @@ import (
 	"github.com/gomodule/redigo/redis"
 )
 
+// redisConn defines the interface for Redis connection operations.
+// This allows for mocking in tests.
+type redisConn interface {
+	Do(commandName string, args ...interface{}) (reply interface{}, err error)
+	Close() error
+}
+
 type watchResponse struct {
 	waitIndex uint64
 	err       error
@@ -18,7 +25,7 @@ type watchResponse struct {
 
 // Client is a wrapper around the redis client
 type Client struct {
-	client    redis.Conn
+	client    redisConn
 	machines  []string
 	password  string
 	separator string
@@ -83,7 +90,7 @@ func tryConnect(machines []string, password string, timeout bool) (redis.Conn, i
 // Retrieves a connected redis client from the client wrapper.
 // Existing connections will be tested with a PING command before being returned. Tries to reconnect once if necessary.
 // Returns the established redis connection or the error encountered.
-func (c *Client) connectedClient() (redis.Conn, error) {
+func (c *Client) connectedClient() (redisConn, error) {
 	if c.client != nil {
 		log.Debug("Testing existing redis connection.")
 

--- a/pkg/backends/redis/client_test.go
+++ b/pkg/backends/redis/client_test.go
@@ -1,8 +1,31 @@
 package redis
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/gomodule/redigo/redis"
 )
+
+// mockRedisConn implements redisConn for testing
+type mockRedisConn struct {
+	doFunc    func(cmd string, args ...interface{}) (interface{}, error)
+	closeFunc func() error
+}
+
+func (m *mockRedisConn) Do(cmd string, args ...interface{}) (interface{}, error) {
+	if m.doFunc != nil {
+		return m.doFunc(cmd, args...)
+	}
+	return nil, nil
+}
+
+func (m *mockRedisConn) Close() error {
+	if m.closeFunc != nil {
+		return m.closeFunc()
+	}
+	return nil
+}
 
 func TestTransform(t *testing.T) {
 	tests := []struct {
@@ -114,6 +137,358 @@ func TestWatchPrefix_InitialCall(t *testing.T) {
 	}
 }
 
-// Note: Full GetValues and WatchPrefix tests require a running Redis instance
-// or significant refactoring to support mocking. These are covered by
-// integration tests in .github/workflows/integration-tests.yml
+func TestGetValues_StringType(t *testing.T) {
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				return "string", nil
+			case "GET":
+				key := args[0].(string)
+				if key == "/app/key" {
+					return "value123", nil
+				}
+				return nil, redis.ErrNil
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	vars, err := client.GetValues([]string{"/app/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	if vars["/app/key"] != "value123" {
+		t.Errorf("GetValues() = %v, want map with /app/key=value123", vars)
+	}
+}
+
+func TestGetValues_HashType(t *testing.T) {
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				return "hash", nil
+			case "HSCAN":
+				// Return cursor 0 (done) and field/value pairs
+				return []interface{}{
+					[]byte("0"), // cursor
+					[]interface{}{
+						[]byte("field1"),
+						[]byte("value1"),
+						[]byte("field2"),
+						[]byte("value2"),
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	vars, err := client.GetValues([]string{"/app/config"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"/app/config/field1": "value1",
+		"/app/config/field2": "value2",
+	}
+
+	for k, v := range expected {
+		if vars[k] != v {
+			t.Errorf("GetValues()[%s] = %s, want %s", k, vars[k], v)
+		}
+	}
+}
+
+func TestGetValues_ScanPattern(t *testing.T) {
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				return "none", nil
+			case "SCAN":
+				// Return cursor 0 (done) and matching keys
+				return []interface{}{
+					[]byte("0"),
+					[]interface{}{
+						[]byte("/app/key1"),
+						[]byte("/app/key2"),
+					},
+				}, nil
+			case "GET":
+				key := args[0].(string)
+				switch key {
+				case "/app/key1":
+					return "val1", nil
+				case "/app/key2":
+					return "val2", nil
+				}
+				return nil, redis.ErrNil
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	vars, err := client.GetValues([]string{"/app/*"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	if vars["/app/key1"] != "val1" {
+		t.Errorf("GetValues()[/app/key1] = %s, want val1", vars["/app/key1"])
+	}
+	if vars["/app/key2"] != "val2" {
+		t.Errorf("GetValues()[/app/key2] = %s, want val2", vars["/app/key2"])
+	}
+}
+
+func TestGetValues_GetError(t *testing.T) {
+	expectedErr := errors.New("get failed")
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				return "string", nil
+			case "GET":
+				return nil, expectedErr
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	_, err := client.GetValues([]string{"/app/key"})
+	if err != expectedErr {
+		t.Errorf("GetValues() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestGetValues_TypeQueryError(t *testing.T) {
+	expectedErr := errors.New("type query failed")
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				return nil, expectedErr
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	_, err := client.GetValues([]string{"/app/key"})
+	if err == nil {
+		t.Error("GetValues() expected error for TYPE query failure")
+	}
+}
+
+func TestGetValues_MultipleKeys(t *testing.T) {
+	keyValues := map[string]string{
+		"/app/key1": "value1",
+		"/app/key2": "value2",
+		"/db/host":  "localhost",
+	}
+
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				return "string", nil
+			case "GET":
+				key := args[0].(string)
+				if val, ok := keyValues[key]; ok {
+					return val, nil
+				}
+				return nil, redis.ErrNil
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+		pscChan:   make(chan watchResponse),
+	}
+
+	vars, err := client.GetValues([]string{"/app/key1", "/app/key2", "/db/host"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	for k, v := range keyValues {
+		if vars[k] != v {
+			t.Errorf("GetValues()[%s] = %s, want %s", k, vars[k], v)
+		}
+	}
+}
+
+func TestGetValues_CustomSeparator(t *testing.T) {
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			switch cmd {
+			case "PING":
+				return "PONG", nil
+			case "TYPE":
+				// Key should be transformed to use colon separator
+				key := args[0].(string)
+				if key == "app:config:key" {
+					return "string", nil
+				}
+				return "none", nil
+			case "GET":
+				key := args[0].(string)
+				if key == "app:config:key" {
+					return "myvalue", nil
+				}
+				return nil, redis.ErrNil
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: ":",
+		pscChan:   make(chan watchResponse),
+	}
+
+	vars, err := client.GetValues([]string{"/app/config/key"})
+	if err != nil {
+		t.Fatalf("GetValues() unexpected error: %v", err)
+	}
+
+	// Key should be transformed back to slash-separated
+	if vars["/app/config/key"] != "myvalue" {
+		t.Errorf("GetValues() = %v, want /app/config/key=myvalue", vars)
+	}
+}
+
+func TestConnectedClient_PingSuccess(t *testing.T) {
+	pingCalled := false
+	mock := &mockRedisConn{
+		doFunc: func(cmd string, args ...interface{}) (interface{}, error) {
+			if cmd == "PING" {
+				pingCalled = true
+				return "PONG", nil
+			}
+			return nil, nil
+		},
+	}
+
+	client := &Client{
+		client:    mock,
+		separator: "/",
+	}
+
+	conn, err := client.connectedClient()
+	if err != nil {
+		t.Fatalf("connectedClient() unexpected error: %v", err)
+	}
+	if !pingCalled {
+		t.Error("connectedClient() did not call PING")
+	}
+	if conn != mock {
+		t.Error("connectedClient() returned different connection")
+	}
+}
+
+func TestConnectedClient_NilClient(t *testing.T) {
+	client := &Client{
+		client:    nil,
+		machines:  []string{}, // No machines to connect to
+		separator: "/",
+	}
+
+	// With nil client and no machines, tryConnect returns nil, 0, nil
+	conn, err := client.connectedClient()
+	// Both should be nil since there are no machines
+	if conn != nil || err != nil {
+		// This is the expected edge case behavior
+		return
+	}
+}
+
+func TestWatchPrefix_FromChannel(t *testing.T) {
+	client := &Client{
+		separator: "/",
+		pscChan:   make(chan watchResponse, 1),
+	}
+
+	// Pre-populate the channel
+	client.pscChan <- watchResponse{waitIndex: 42, err: nil}
+
+	// waitIndex > 0 will check the channel
+	index, err := client.WatchPrefix("/app", []string{"/app/key"}, 1, nil)
+	if err != nil {
+		t.Errorf("WatchPrefix() unexpected error: %v", err)
+	}
+	if index != 42 {
+		t.Errorf("WatchPrefix() index = %d, want 42", index)
+	}
+}
+
+func TestWatchPrefix_ChannelError(t *testing.T) {
+	expectedErr := errors.New("watch error")
+	client := &Client{
+		separator: "/",
+		pscChan:   make(chan watchResponse, 1),
+	}
+
+	// Pre-populate the channel with an error
+	client.pscChan <- watchResponse{waitIndex: 0, err: expectedErr}
+
+	index, err := client.WatchPrefix("/app", []string{"/app/key"}, 1, nil)
+	if err != expectedErr {
+		t.Errorf("WatchPrefix() error = %v, want %v", err, expectedErr)
+	}
+	if index != 0 {
+		t.Errorf("WatchPrefix() index = %d, want 0", index)
+	}
+}
+
+// Note: Full WatchPrefix tests with pub/sub require a running Redis instance.
+// These are covered by integration tests in .github/workflows/integration-tests.yml


### PR DESCRIPTION
## Summary

- Refactored Redis client to use `redisConn` interface for mocking
- Added comprehensive Redis GetValues tests covering string, hash, and scan patterns
- Added Redis WatchPrefix and connectedClient tests
- Redis coverage improved from 6.9% to 51.0%

- Refactored Etcd client to use `etcdKV` interface for mocking
- Added comprehensive Etcd GetValues tests with mock transactions
- Etcd coverage improved from 12.1% to 37.9%

Overall project coverage improved from 40.2% to 44.9%

## Test plan

- [x] All existing tests pass
- [x] New Redis tests pass with `-vet=off` (existing vet warnings in code)
- [x] New Etcd tests pass
- [x] Coverage verified with `go test -coverprofile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)