### PR TITLE
test: Improve Etcd and Consul backend test coverage

### DIFF
--- a/pkg/backends/consul/client_test.go
+++ b/pkg/backends/consul/client_test.go
@@ -243,3 +243,62 @@ func TestWatchPrefix_Error(t *testing.T) {
 		t.Error("WatchPrefix() expected error, got nil")
 	}
 }
+
+func TestNew_BasicConfiguration(t *testing.T) {
+	// Test New with basic configuration
+	client, err := New([]string{"localhost:8500"}, "http", "", "", "", false, "", "")
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client")
+	}
+}
+
+func TestNew_WithNodes(t *testing.T) {
+	// Test New with multiple nodes (should use first node)
+	client, err := New([]string{"node1:8500", "node2:8500", "node3:8500"}, "http", "", "", "", false, "", "")
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client")
+	}
+}
+
+func TestNew_EmptyNodes(t *testing.T) {
+	// Test New with empty nodes list (should use default Consul address)
+	client, err := New([]string{}, "http", "", "", "", false, "", "")
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client")
+	}
+}
+
+func TestNew_WithBasicAuth(t *testing.T) {
+	// Test New with basic authentication
+	client, err := New([]string{"localhost:8500"}, "http", "", "", "", true, "user", "pass")
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client")
+	}
+}
+
+func TestNew_WithHTTPS(t *testing.T) {
+	// Test New with HTTPS scheme
+	client, err := New([]string{"localhost:8500"}, "https", "", "", "", false, "", "")
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Error("New() returned nil client")
+	}
+}
+
+// Note: TLS configuration tests with valid certificates require integration tests
+// as the Consul SDK validates certificate content. The basic New() tests above
+// cover the config setup paths that don't require certificate validation.


### PR DESCRIPTION
## Summary
- Add comprehensive tests for Etcd backend batch operations, edge cases, and WatchPrefix scenarios
- Add tests for Consul backend `New()` function covering various configuration options
- Improve overall test coverage from 51.0% to 53.4%

## Coverage Changes
| Package | Before | After |
|---------|--------|-------|
| Consul | 57.1% | 88.6% |
| Etcd | 37.9% | 55.6% |
| **Overall** | 51.0% | 53.4% |

## New Tests

### Etcd
- `TestGetValues_BatchOperation` - Tests batching when >128 keys
- `TestGetValues_KeyWithTrailingSlash` - Tests keys with trailing slashes
- `TestGetValues_RevisionConsistency` - Tests revision tracking across batches
- `TestGetValues_ExactKeyMatch` - Tests exact key matching behavior
- `TestWatchPrefix_StopChan` - Tests WatchPrefix with stop channel
- `TestWatch_WaitNext_NotifyAfterRevisionUpdate` - Tests notification after revision update
- `TestWatch_WaitNext_NotifyCancelledDuringWait` - Tests cancellation during wait
- `TestWatch_WaitNext_NotifyCancelledAfterBreak` - Tests cancellation after break

### Consul
- `TestNew_BasicConfiguration` - Tests basic client creation
- `TestNew_WithNodes` - Tests with multiple nodes (uses first)
- `TestNew_EmptyNodes` - Tests with empty node list (uses default)
- `TestNew_WithBasicAuth` - Tests basic auth configuration
- `TestNew_WithHTTPS` - Tests HTTPS scheme

## Test plan
- [x] All new tests pass locally
- [x] Full test suite passes with `-vet=off` (matching CI configuration)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)