### PR TITLE
docs: Update CHANGELOG with releases v0.19.2 through v0.31.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,62 @@
-### v0.20.0
+### v0.32.0
 
 **BREAKING CHANGE**: The global `prefix` setting in `confd.toml` is now concatenated with resource-level `prefix` values in template resource files (`conf.d/*.toml`) instead of overriding them. For example, if `confd.toml` has `prefix = "production"` and a resource has `prefix = "myapp"`, the effective prefix is now `/production/myapp` instead of `/production`. To restore the previous behavior, remove the `prefix` setting from your template resource files. (#109)
+
+### v0.31.1
+
+* chore: Update goreleaser config to version 2
+* fix: Update go.mod to mark etcd/api/v3 as direct dependency
+
+### v0.31.0
+
+* test: Improve Etcd and Consul backend test coverage (#322)
+* test: Improve Vault and Zookeeper test coverage (#321)
+* test: Improve Redis and Etcd test coverage (#320)
+* test: Improve test coverage from 13% to 40% (#319)
+* Update Go to 1.23.12 (#309)
+* Update deprecated use of ioutil (#286, #271)
+* Bump golang.org/x/crypto from 0.40.0 to 0.45.0 (#318)
+* Bump go.etcd.io/etcd/client/v3 from 3.5.18 to 3.6.6
+* Bump github.com/hashicorp/vault/api from 1.15.0 to 1.22.0
+* Bump github.com/hashicorp/consul/api from 1.29.4 to 1.31.2
+* Bump github.com/fsnotify/fsnotify from 1.7.0 to 1.9.0
+* Bump github.com/BurntSushi/toml from 1.4.0 to 1.5.0
+
+### v0.30.0
+
+**BREAKING CHANGE**: Vault KV v2 configurations that include `/data/` in the key path are no longer supported. The Vault backend now properly handles the `/data/` path component internally. Use `prefix` for the Secrets Engine path instead.
+
+* refactor: Broadly refactor Vault client to properly handle KV v1 and KV v2 (#270)
+* Upgrade Go version from 1.20 to 1.21 (#242)
+* Add proper integration check for nested config (#248)
+* Bump github.com/hashicorp/go-retryablehttp from 0.7.1 to 0.7.7 (#258)
+* Bump github.com/hashicorp/vault/api from 1.9.1 to 1.13.0
+* Bump github.com/hashicorp/consul/api from 1.26.1 to 1.28.3
+* Bump go.etcd.io/etcd/client/v3 from 3.5.11 to 3.5.13
+* Bump github.com/gomodule/redigo from 1.8.9 to 1.9.2
+* Bump golang.org/x/crypto from 0.14.0 to 0.17.0
+* Bump golang.org/x/net from 0.17.0 to 0.23.0
+
+### v0.20.0
+
+* Update Go version from 1.19.5 to 1.20 (#200)
+* Bump github.com/hashicorp/consul/api from 1.18.0 to 1.26.1 (#199)
+* Bump go.etcd.io/etcd/client/v3 from 3.5.7 to 3.5.11 (#195)
+* Bump github.com/hashicorp/vault/api from 1.8.3 to 1.9.1 (#192)
+* Bump github.com/fsnotify/fsnotify from 1.6.0 to 1.7.0 (#198)
+* Bump github.com/sirupsen/logrus from 1.9.0 to 1.9.3
+* Bump github.com/BurntSushi/toml from 1.2.1 to 1.3.2 (#196)
+* Bump golang.org/x/net from 0.1.0 to 0.17.0
+
+### v0.19.2
+
+* fix: Allow env var precedence for SSM region (#133)
+* fix: Updates golang.org/x/text to 0.3.8 (#137)
+* Bump github.com/aws/aws-sdk-go from 1.44.95 to 1.44.196 (#158)
+* Bump github.com/hashicorp/vault/api from 1.7.2 to 1.8.3
+* Bump go.etcd.io/etcd/client/v3 from 3.5.4 to 3.5.7 (#153)
+* Bump github.com/hashicorp/consul/api from 1.14.0 to 1.18.0 (#144)
+* Bump github.com/fsnotify/fsnotify from 1.5.4 to 1.6.0 (#127)
 
 ### v0.19.1
 


### PR DESCRIPTION
## Summary

The CHANGELOG was significantly out of date, missing entries for multiple releases. This PR adds the missing changelog entries to align with actual GitHub releases.

## Changes

Added changelog entries for:

- **v0.32.0** (upcoming): Prefix concatenation fix (#109) - BREAKING CHANGE
- **v0.31.1**: goreleaser v2 config, etcd dependency fix
- **v0.31.0**: Test coverage improvements (13% → 40%), Go 1.23.12, dependency updates
- **v0.30.0**: Vault backend refactor for proper KV v1/v2 handling - BREAKING CHANGE
- **v0.20.0**: Go 1.20 update, dependency bumps
- **v0.19.2**: SSM region environment variable fix, security updates

## Test plan

- [x] Verified changelog entries match GitHub release notes
- [x] Version numbers follow correct sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)