### PR TITLE
feat: Add template variable support in reload_cmd

### DIFF
--- a/docs/template-resources.md
+++ b/docs/template-resources.md
@@ -14,7 +14,7 @@ Template resources are stored under the `/etc/confd/conf.d` directory by default
 * `gid` (int) - The gid that should own the file. Defaults to the effective gid.
 * `mode` (string) - The permission mode of the file.
 * `uid` (int) - The uid that should own the file. Defaults to the effective uid.
-* `reload_cmd` (string) - The command to reload config.
+* `reload_cmd` (string) - The command to reload config. Use `{{.src}}` to reference the rendered source template, or `{{.dest}}` to reference the destination file.
 * `check_cmd` (string) - The command to check config. Use `{{.src}}` to reference the rendered source template.
 * `prefix` (string) - The string to prefix to keys. When a global prefix is also set in `confd.toml`, the prefixes are concatenated (e.g., global `production` + resource `myapp` = `/production/myapp`).
 


### PR DESCRIPTION
## Summary

- Add support for `{{.src}}` and `{{.dest}}` template variables in `reload_cmd`
- Matches existing functionality already available in `check_cmd`
- Allows reload commands to reference the staged file path or destination file path

## Changes

- Modified `reload()` method in `pkg/template/resource.go` to parse reload command as a Go template
- Updated documentation in `docs/template-resources.md`
- Added unit tests for template substitution in `pkg/template/resource_test.go`

## Usage Example

```toml
[template]
src = "nginx.conf.tmpl"
dest = "/etc/nginx/nginx.conf"
keys = ["/nginx"]
reload_cmd = "/usr/local/bin/config-reload.sh {{.dest}}"
```

## Test plan

- [x] Unit tests pass for template substitution
- [x] All existing tests pass
- [ ] Manual testing with a reload_cmd using `{{.dest}}`

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)