### PR TITLE
feat: Add JSON log format support

### DIFF
--- a/cmd/confd/config.go
+++ b/cmd/confd/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	SRVDomain      string `toml:"srv_domain"`
 	SRVRecord      string `toml:"srv_record"`
 	LogLevel       string `toml:"log-level"`
+	LogFormat      string `toml:"log-format"`
 	Watch          bool   `toml:"watch"`
 	PrintVersion   bool
 	ConfigFile     string
@@ -51,6 +52,7 @@ func init() {
 	flag.IntVar(&config.Interval, "interval", 600, "backend polling interval")
 	flag.BoolVar(&config.KeepStageFile, "keep-stage-file", false, "keep staged files")
 	flag.StringVar(&config.LogLevel, "log-level", "", "level which confd should log messages")
+	flag.StringVar(&config.LogFormat, "log-format", "", "format of log messages (text or json)")
 	flag.Var(&config.BackendNodes, "node", "list of backend nodes")
 	flag.BoolVar(&config.Noop, "noop", false, "only show pending changes")
 	flag.BoolVar(&config.OneTime, "onetime", false, "run once and exit")
@@ -100,6 +102,10 @@ func initConfig() error {
 
 	if config.LogLevel != "" {
 		log.SetLevel(config.LogLevel)
+	}
+
+	if config.LogFormat != "" {
+		log.SetFormat(config.LogFormat)
 	}
 
 	if config.SRVDomain != "" && config.SRVRecord == "" {

--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -36,6 +36,8 @@ Usage of confd:
       backend polling interval (default 600)
   -keep-stage-file
       keep staged files
+  -log-format string
+      format of log messages (text or json)
   -log-level string
       level which confd should log messages
   -node value

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -13,6 +13,7 @@ Optional:
 * `client_key` (string) - The client key file.
 * `confdir` (string) - The path to confd configs. ("/etc/confd")
 * `interval` (int) - The backend polling interval in seconds. (600)
+* `log-format` (string) - format of log messages ("text" or "json")
 * `log-level` (string) - level which confd should log messages ("info")
 * `nodes` (array of strings) - List of backend nodes. (["http://127.0.0.1:4001"])
 * `noop` (bool) - Enable noop mode. Process all template resources; skip target update.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -48,6 +48,18 @@ func SetLevel(level string) {
 	log.SetLevel(lvl)
 }
 
+// SetFormat sets the log format. Valid formats are "text" and "json".
+func SetFormat(format string) {
+	switch format {
+	case "json":
+		log.SetFormatter(&log.JSONFormatter{})
+	case "text":
+		log.SetFormatter(&ConfdFormatter{})
+	default:
+		Fatal(fmt.Sprintf(`not a valid log format: "%s"`, format))
+	}
+}
+
 // Debug logs a message with severity DEBUG.
 func Debug(format string, v ...interface{}) {
 	log.Debug(fmt.Sprintf(format, v...))


### PR DESCRIPTION
## Summary

- Add `--log-format` flag to switch between text and JSON log output
- Leverages existing logrus `JSONFormatter` for structured logging
- Makes log entries easier to parse by log indexing solutions (ELK, Splunk, etc.)

## Changes

- Added `SetFormat()` function to `pkg/log/log.go`
- Added `--log-format` flag and `log-format` config option to `cmd/confd/config.go`
- Updated documentation in `docs/command-line-flags.md` and `docs/configuration-guide.md`

## Usage

Command line:
```bash
confd -backend=env -log-format=json -onetime
```

Config file (`confd.toml`):
```toml
log-format = "json"
```

## Example Output

**Text format (default):**
```
2026-01-07T01:30:00Z hostname confd[1234]: INFO Backend set to env
```

**JSON format:**
```json
{"level":"info","msg":"Backend set to env","time":"2026-01-07T01:30:00Z"}
```

## Test plan

- [x] All existing tests pass
- [x] Build succeeds
- [x] `-help` shows new flag
- [ ] Manual testing with `-log-format=json`

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)