### PR TITLE
chore: Code quality cleanup and godoc improvements

### DIFF
--- a/pkg/backends/client.go
+++ b/pkg/backends/client.go
@@ -82,5 +82,5 @@ func New(config Config) (StoreClient, error) {
 	case "ssm":
 		return ssm.New()
 	}
-	return nil, errors.New("Invalid backend")
+	return nil, errors.New("invalid backend")
 }

--- a/pkg/backends/client_test.go
+++ b/pkg/backends/client_test.go
@@ -15,8 +15,8 @@ func TestNew_InvalidBackend(t *testing.T) {
 	if err == nil {
 		t.Error("New() expected error for invalid backend, got nil")
 	}
-	if err.Error() != "Invalid backend" {
-		t.Errorf("New() error = %v, want 'Invalid backend'", err)
+	if err.Error() != "invalid backend" {
+		t.Errorf("New() error = %v, want 'invalid backend'", err)
 	}
 }
 
@@ -68,9 +68,9 @@ func TestNew_DefaultBackendIsEtcd(t *testing.T) {
 	// This will fail to connect, but we can verify it tries etcd
 	_, err := New(config)
 	// Error is expected since there's no etcd server
-	// The important thing is it doesn't return "Invalid backend"
-	if err != nil && err.Error() == "Invalid backend" {
-		t.Error("New() with empty backend should default to etcd, not return 'Invalid backend'")
+	// The important thing is it doesn't return "invalid backend"
+	if err != nil && err.Error() == "invalid backend" {
+		t.Error("New() with empty backend should default to etcd, not return 'invalid backend'")
 	}
 }
 

--- a/pkg/backends/config.go
+++ b/pkg/backends/config.go
@@ -4,6 +4,7 @@ import (
 	util "github.com/abtreece/confd/pkg/util"
 )
 
+// Config holds the configuration for backend connections.
 type Config struct {
 	AuthToken      string     `toml:"auth_token"`
 	AuthType       string     `toml:"auth_type"`

--- a/pkg/backends/etcd/client.go
+++ b/pkg/backends/etcd/client.go
@@ -20,11 +20,6 @@ type etcdKV interface {
 	Txn(ctx context.Context) clientv3.Txn
 }
 
-// etcdWatcher defines the interface for etcd watch operations.
-type etcdWatcher interface {
-	Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
-}
-
 // A watch only tells the latest revision
 type Watch struct {
 	// Last seen revision

--- a/pkg/backends/file/client.go
+++ b/pkg/backends/file/client.go
@@ -15,19 +15,19 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var replacer = strings.NewReplacer("/", "_")
-
 // Client provides a shell for the yaml client
 type Client struct {
 	filepath []string
 	filter   string
 }
 
+// ResultError holds a response code and error from file watch operations.
 type ResultError struct {
 	response uint64
 	err      error
 }
 
+// NewFileClient creates a new file backend client for reading YAML/JSON files.
 func NewFileClient(filepath []string, filter string) (*Client, error) {
 	return &Client{filepath: filepath, filter: filter}, nil
 }
@@ -54,7 +54,7 @@ func readFile(path string, vars map[string]string) error {
 		}
 		err = nodeWalk(fileMap, "/", vars)
 	default:
-		err = fmt.Errorf("Invalid file extentsion. YAML or JSON only.")
+		err = fmt.Errorf("invalid file extension, YAML or JSON only")
 	}
 
 	if err != nil {

--- a/pkg/backends/ssm/client.go
+++ b/pkg/backends/ssm/client.go
@@ -19,10 +19,12 @@ type ssmAPI interface {
 	GetParametersByPathPages(input *ssm.GetParametersByPathInput, fn func(*ssm.GetParametersByPathOutput, bool) bool) error
 }
 
+// Client is a wrapper around the AWS SSM client.
 type Client struct {
 	client ssmAPI
 }
 
+// New creates a new SSM client with automatic region detection.
 func New() (*Client, error) {
 
 	// Attempt to get AWS Region from ec2metadata. Should determine how to

--- a/pkg/backends/vault/client.go
+++ b/pkg/backends/vault/client.go
@@ -95,9 +95,9 @@ func authenticate(c *vaultapi.Client, authType string, params map[string]string)
 			"password": password,
 		})
 	case "kubernetes":
-		jwt, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
-		if err != nil {
-			return err
+		jwt, jwtErr := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+		if jwtErr != nil {
+			return jwtErr
 		}
 		secret, err = c.Logical().Write(url, map[string]interface{}{
 			"jwt":  string(jwt[:]),
@@ -138,7 +138,6 @@ func getConfig(address, cert, key, caCert string) (*vaultapi.Config, error) {
 			return nil, err
 		}
 		tlsConfig.Certificates = []tls.Certificate{clientCert}
-		tlsConfig.BuildNameToCertificate()
 	}
 
 	if caCert != "" {

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -9,10 +9,12 @@ import (
 	util "github.com/abtreece/confd/pkg/util"
 )
 
+// Processor defines the interface for template processing strategies.
 type Processor interface {
 	Process()
 }
 
+// Process loads and processes all template resources once.
 func Process(config Config) error {
 	ts, err := getTemplateResources(config)
 	if err != nil {
@@ -40,6 +42,7 @@ type intervalProcessor struct {
 	interval int
 }
 
+// IntervalProcessor creates a processor that polls for changes at a fixed interval.
 func IntervalProcessor(config Config, stopChan, doneChan chan bool, errChan chan error, interval int) Processor {
 	return &intervalProcessor{config, stopChan, doneChan, errChan, interval}
 }
@@ -55,7 +58,7 @@ func (p *intervalProcessor) Process() {
 		process(ts)
 		select {
 		case <-p.stopChan:
-			break
+			return
 		case <-time.After(time.Duration(p.interval) * time.Second):
 			continue
 		}
@@ -70,6 +73,7 @@ type watchProcessor struct {
 	wg       sync.WaitGroup
 }
 
+// WatchProcessor creates a processor that watches for backend changes continuously.
 func WatchProcessor(config Config, stopChan, doneChan chan bool, errChan chan error) Processor {
 	var wg sync.WaitGroup
 	return &watchProcessor{config, stopChan, doneChan, errChan, wg}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -31,6 +31,7 @@ type FileInfo struct {
 	Md5  string
 }
 
+// AppendPrefix prepends the given prefix to each key in the slice.
 func AppendPrefix(prefix string, keys []string) []string {
 	s := make([]string, len(keys))
 	for i, k := range keys {
@@ -39,6 +40,7 @@ func AppendPrefix(prefix string, keys []string) []string {
 	return s
 }
 
+// ArrayShift inserts a value at the specified position in the array.
 func ArrayShift(array *[]string, position int, value string) {
 	*array = append(*array, "")
 	copy((*array)[position+1:], (*array)[position:])


### PR DESCRIPTION
## Summary

- Remove unused code (etcdWatcher interface, replacer variable)
- Fix bugs (ineffective break, variable shadowing, deprecated API call)
- Fix error strings per Go conventions
- Add godoc comments for exported types and functions

## Changes

### Dead Code Removed
- `pkg/backends/etcd/client.go`: Removed unused `etcdWatcher` interface
- `pkg/backends/file/client.go`: Removed unused `replacer` variable

### Bug Fixes
- `pkg/template/processor.go`: Fixed ineffective `break` statement - changed to `return` to properly exit the for loop
- `pkg/backends/vault/client.go`: Fixed variable shadowing in kubernetes auth case
- `pkg/backends/vault/client.go`: Removed deprecated `tlsConfig.BuildNameToCertificate()` (deprecated since Go 1.14)

### Error String Fixes
- Lowercase error messages per Go conventions
- Removed trailing punctuation

### Godoc Comments Added
- `backends.Config`, `ssm.Client`, `ssm.New`
- `file.ResultError`, `file.NewFileClient`
- `template.Processor`, `template.Process`, `template.IntervalProcessor`, `template.WatchProcessor`
- `util.AppendPrefix`, `util.ArrayShift`

## Test plan

- [x] All unit tests pass (`go test -vet=off ./pkg/...`)
- [x] Build succeeds (`go build ./...`)

Closes #349, #348