### PR TITLE
chore: Add benchmark suite for template and backend performance

### DIFF
--- a/pkg/backends/env/benchmark_test.go
+++ b/pkg/backends/env/benchmark_test.go
@@ -1,0 +1,58 @@
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+func BenchmarkGetValues_SingleKey(b *testing.B) {
+	client, _ := NewEnvClient()
+	os.Setenv("BENCH_TEST_KEY", "test_value")
+	defer os.Unsetenv("BENCH_TEST_KEY")
+
+	keys := []string{"/bench/test/key"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkGetValues_MultipleKeys(b *testing.B) {
+	client, _ := NewEnvClient()
+	for i := 0; i < 10; i++ {
+		os.Setenv("BENCH_KEY_"+string(rune('A'+i)), "value")
+	}
+	defer func() {
+		for i := 0; i < 10; i++ {
+			os.Unsetenv("BENCH_KEY_" + string(rune('A'+i)))
+		}
+	}()
+
+	keys := []string{
+		"/bench/key/a", "/bench/key/b", "/bench/key/c",
+		"/bench/key/d", "/bench/key/e", "/bench/key/f",
+		"/bench/key/g", "/bench/key/h", "/bench/key/i", "/bench/key/j",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkTransform(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		transform("/app/database/host")
+	}
+}
+
+func BenchmarkClean(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		clean("APP_DATABASE_HOST")
+	}
+}
+
+func BenchmarkNewEnvClient(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewEnvClient()
+	}
+}

--- a/pkg/backends/file/benchmark_test.go
+++ b/pkg/backends/file/benchmark_test.go
@@ -1,0 +1,175 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkGetValues_SmallYAML(b *testing.B) {
+	tmpDir := b.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+	content := `
+database:
+  host: localhost
+  port: 5432
+  name: mydb
+`
+	os.WriteFile(yamlFile, []byte(content), 0644)
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+	keys := []string{"/database"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkGetValues_MediumYAML(b *testing.B) {
+	tmpDir := b.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+	content := `
+database:
+  host: localhost
+  port: 5432
+  name: mydb
+  user: admin
+  password: secret
+  pool_size: 10
+  timeout: 30
+cache:
+  enabled: true
+  ttl: 3600
+  max_size: 1000
+logging:
+  level: info
+  format: json
+  output: stdout
+server:
+  host: 0.0.0.0
+  port: 8080
+  read_timeout: 30
+  write_timeout: 30
+`
+	os.WriteFile(yamlFile, []byte(content), 0644)
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+	keys := []string{"/"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkGetValues_LargeYAML(b *testing.B) {
+	tmpDir := b.TempDir()
+	yamlFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Generate a larger YAML file
+	content := "services:\n"
+	for i := 0; i < 50; i++ {
+		content += "  service" + string(rune('a'+i%26)) + ":\n"
+		content += "    host: localhost\n"
+		content += "    port: " + string(rune('0'+i%10)) + "000\n"
+		content += "    enabled: true\n"
+		content += "    timeout: 30\n"
+	}
+	os.WriteFile(yamlFile, []byte(content), 0644)
+
+	client, _ := NewFileClient([]string{yamlFile}, "")
+	keys := []string{"/services"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkGetValues_JSON(b *testing.B) {
+	tmpDir := b.TempDir()
+	jsonFile := filepath.Join(tmpDir, "config.json")
+	content := `{
+  "database": {
+    "host": "localhost",
+    "port": 5432,
+    "name": "mydb"
+  },
+  "cache": {
+    "enabled": true,
+    "ttl": 3600
+  }
+}`
+	os.WriteFile(jsonFile, []byte(content), 0644)
+
+	client, _ := NewFileClient([]string{jsonFile}, "")
+	keys := []string{"/"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkGetValues_MultipleFiles(b *testing.B) {
+	tmpDir := b.TempDir()
+	files := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		files[i] = filepath.Join(tmpDir, "config"+string(rune('a'+i))+".yaml")
+		content := "key" + string(rune('a'+i)) + ": value" + string(rune('a'+i)) + "\n"
+		os.WriteFile(files[i], []byte(content), 0644)
+	}
+
+	client, _ := NewFileClient(files, "")
+	keys := []string{"/"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client.GetValues(keys)
+	}
+}
+
+func BenchmarkNewFileClient(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewFileClient([]string{"/tmp/config.yaml"}, "*.yaml")
+	}
+}
+
+func BenchmarkNodeWalk_Flat(b *testing.B) {
+	node := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+		"key4": "value4",
+		"key5": "value5",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vars := make(map[string]string)
+		nodeWalk(node, "/", vars)
+	}
+}
+
+func BenchmarkNodeWalk_Nested(b *testing.B) {
+	node := map[string]interface{}{
+		"level1": map[string]interface{}{
+			"level2": map[string]interface{}{
+				"level3": map[string]interface{}{
+					"key": "value",
+				},
+			},
+		},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vars := make(map[string]string)
+		nodeWalk(node, "/", vars)
+	}
+}
+
+func BenchmarkNodeWalk_Array(b *testing.B) {
+	node := map[string]interface{}{
+		"items": []interface{}{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vars := make(map[string]string)
+		nodeWalk(node, "/", vars)
+	}
+}

--- a/pkg/template/benchmark_test.go
+++ b/pkg/template/benchmark_test.go
@@ -1,0 +1,270 @@
+package template
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/kelseyhightower/memkv"
+)
+
+// Benchmark template functions
+
+func BenchmarkSeq_Small(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Seq(1, 10)
+	}
+}
+
+func BenchmarkSeq_Large(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Seq(1, 1000)
+	}
+}
+
+func BenchmarkReverse_Strings(b *testing.B) {
+	values := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Make a copy to avoid modifying the original
+		v := make([]string, len(values))
+		copy(v, values)
+		Reverse(v)
+	}
+}
+
+func BenchmarkReverse_KVPairs(b *testing.B) {
+	values := []memkv.KVPair{
+		{Key: "/a", Value: "1"},
+		{Key: "/b", Value: "2"},
+		{Key: "/c", Value: "3"},
+		{Key: "/d", Value: "4"},
+		{Key: "/e", Value: "5"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := make([]memkv.KVPair, len(values))
+		copy(v, values)
+		Reverse(v)
+	}
+}
+
+func BenchmarkSortByLength(b *testing.B) {
+	values := []string{"short", "a", "medium length", "longer string here", "b"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := make([]string, len(values))
+		copy(v, values)
+		SortByLength(v)
+	}
+}
+
+func BenchmarkSortKVByLength(b *testing.B) {
+	values := []memkv.KVPair{
+		{Key: "/short", Value: "1"},
+		{Key: "/a", Value: "2"},
+		{Key: "/medium/length/key", Value: "3"},
+		{Key: "/longer/path/here/now", Value: "4"},
+		{Key: "/b", Value: "5"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := make([]memkv.KVPair, len(values))
+		copy(v, values)
+		SortKVByLength(v)
+	}
+}
+
+func BenchmarkBase64Encode(b *testing.B) {
+	data := "Hello, World! This is a test string for base64 encoding."
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Base64Encode(data)
+	}
+}
+
+func BenchmarkBase64Decode(b *testing.B) {
+	data := "SGVsbG8sIFdvcmxkISBUaGlzIGlzIGEgdGVzdCBzdHJpbmcgZm9yIGJhc2U2NCBlbmNvZGluZy4="
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Base64Decode(data)
+	}
+}
+
+func BenchmarkUnmarshalJsonObject(b *testing.B) {
+	data := `{"name": "test", "value": 123, "enabled": true, "tags": ["a", "b", "c"]}`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		UnmarshalJsonObject(data)
+	}
+}
+
+func BenchmarkUnmarshalJsonArray(b *testing.B) {
+	data := `[{"name": "item1"}, {"name": "item2"}, {"name": "item3"}]`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		UnmarshalJsonArray(data)
+	}
+}
+
+func BenchmarkCreateMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		CreateMap("key1", "value1", "key2", "value2", "key3", "value3")
+	}
+}
+
+func BenchmarkGetenv_Exists(b *testing.B) {
+	b.Setenv("BENCHMARK_TEST_VAR", "test_value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Getenv("BENCHMARK_TEST_VAR")
+	}
+}
+
+func BenchmarkGetenv_NotExists_WithDefault(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Getenv("NONEXISTENT_VAR_12345", "default_value")
+	}
+}
+
+// Benchmark template compilation and execution
+
+func BenchmarkTemplateCompile_Small(b *testing.B) {
+	tmplStr := `key: {{.Key}}
+value: {{.Value}}`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		template.New("test").Parse(tmplStr)
+	}
+}
+
+func BenchmarkTemplateCompile_Medium(b *testing.B) {
+	tmplStr := `# Configuration file
+{{range .Items}}
+[{{.Name}}]
+host = {{.Host}}
+port = {{.Port}}
+enabled = {{.Enabled}}
+{{end}}
+
+[global]
+timeout = {{.Timeout}}
+retries = {{.Retries}}`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		template.New("test").Parse(tmplStr)
+	}
+}
+
+func BenchmarkTemplateCompile_Large(b *testing.B) {
+	// Build a larger template
+	var sb strings.Builder
+	sb.WriteString("# Large configuration\n")
+	for i := 0; i < 50; i++ {
+		sb.WriteString(`{{if .Enabled}}
+[section` + string(rune('a'+i%26)) + `]
+key = {{.Key}}
+value = {{.Value}}
+{{end}}
+`)
+	}
+	tmplStr := sb.String()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		template.New("test").Parse(tmplStr)
+	}
+}
+
+func BenchmarkTemplateExecute_Small(b *testing.B) {
+	tmplStr := `key: {{.Key}}
+value: {{.Value}}`
+	tmpl, _ := template.New("test").Parse(tmplStr)
+	data := map[string]string{"Key": "testkey", "Value": "testvalue"}
+	var sb strings.Builder
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sb.Reset()
+		tmpl.Execute(&sb, data)
+	}
+}
+
+func BenchmarkTemplateExecute_WithFuncs(b *testing.B) {
+	funcs := newFuncMap()
+	tmplStr := `key: {{base .Key}}
+value: {{toUpper .Value}}
+seq: {{range seq 1 5}}{{.}} {{end}}`
+	tmpl, _ := template.New("test").Funcs(funcs).Parse(tmplStr)
+	data := map[string]string{"Key": "/path/to/key", "Value": "testvalue"}
+	var sb strings.Builder
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sb.Reset()
+		tmpl.Execute(&sb, data)
+	}
+}
+
+func BenchmarkTemplateExecute_Range(b *testing.B) {
+	tmplStr := `{{range .Items}}
+name: {{.Name}}
+value: {{.Value}}
+{{end}}`
+	tmpl, _ := template.New("test").Parse(tmplStr)
+	items := make([]map[string]string, 20)
+	for i := 0; i < 20; i++ {
+		items[i] = map[string]string{"Name": "item", "Value": "value"}
+	}
+	data := map[string]interface{}{"Items": items}
+	var sb strings.Builder
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sb.Reset()
+		tmpl.Execute(&sb, data)
+	}
+}
+
+// Benchmark memkv store operations (used internally by templates)
+
+func BenchmarkMemkvStore_Set(b *testing.B) {
+	store := memkv.New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store.Set("/test/key", "value")
+	}
+}
+
+func BenchmarkMemkvStore_Get(b *testing.B) {
+	store := memkv.New()
+	store.Set("/test/key", "value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store.Get("/test/key")
+	}
+}
+
+func BenchmarkMemkvStore_GetAll(b *testing.B) {
+	store := memkv.New()
+	for i := 0; i < 100; i++ {
+		store.Set("/test/key"+string(rune('a'+i%26)), "value")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store.GetAll("/test/*")
+	}
+}
+
+func BenchmarkMemkvStore_SetMany(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store := memkv.New()
+		for j := 0; j < 100; j++ {
+			store.Set("/app/config/key"+string(rune('a'+j%26)), "value")
+		}
+	}
+}
+
+// Benchmark newFuncMap creation
+func BenchmarkNewFuncMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		newFuncMap()
+	}
+}


### PR DESCRIPTION
## Summary

Add comprehensive benchmarks for measuring and tracking template rendering and backend performance.

## Benchmarks Added

### Template Benchmarks (`pkg/template/benchmark_test.go`)
- **Function benchmarks**: Seq, Reverse, SortByLength, Base64Encode/Decode, JSON unmarshaling, CreateMap, Getenv
- **Template compilation**: Small, medium, and large templates
- **Template execution**: Simple, with custom funcs, with range loops
- **memkv store**: Set, Get, GetAll operations

### Env Backend Benchmarks (`pkg/backends/env/benchmark_test.go`)
- GetValues with single and multiple keys
- Transform and clean helper functions

### File Backend Benchmarks (`pkg/backends/file/benchmark_test.go`)
- YAML file parsing (small, medium, large)
- JSON file parsing
- Multiple file handling
- nodeWalk traversal (flat, nested, array structures)

## Sample Results

```
BenchmarkSeq_Small-8                       1334066     88.01 ns/op
BenchmarkBase64Encode-8                    2153281     53.87 ns/op
BenchmarkTemplateCompile_Small-8             72852   1610 ns/op
BenchmarkTemplateExecute_Small-8            422665    306.4 ns/op
BenchmarkMemkvStore_Get-8                  5351478     22.27 ns/op
BenchmarkGetValues_SmallYAML-8                3898  26373 ns/op
```

## Usage

```bash
# Run all benchmarks
go test -bench=. -benchmem ./pkg/template/...
go test -bench=. -benchmem ./pkg/backends/env/...
go test -bench=. -benchmem ./pkg/backends/file/...

# Compare benchmarks
go test -bench=. ./... > old.txt
# make changes
go test -bench=. ./... > new.txt
benchstat old.txt new.txt
```

## Test plan

- [x] All benchmarks run successfully
- [x] Unit tests still pass

Closes #350