### PR TITLE
docs: Update documentation for new CLI syntax and add backend READMEs

### DIFF
--- a/docs/command-line-flags.md
+++ b/docs/command-line-flags.md
@@ -2,84 +2,244 @@
 
 Command line flags override the confd [configuration file](configuration-guide.md).
 
-```
-confd -h
+confd uses a subcommand-based CLI where you specify the backend as a subcommand:
+
+```bash
+confd <backend> [flags]
 ```
 
-```Text
-Usage of confd:
-  -app-id string
-      Vault app-id to use with the app-id backend (only used with -backend=vault and auth-type=app-id)
-  -auth-token string
-      Auth bearer token to use
-  -auth-type string
-      Vault auth backend type to use (only used with -backend=vault)
-  -backend string
-      backend to use (default "etcd")
-  -basic-auth
-      Use Basic Auth to authenticate (only used with -backend=consul and -backend=etcd)
-  -client-ca-keys string
-      client ca keys
-  -client-cert string
-      the client cert
-  -client-key string
-      the client key
-  -confdir string
-      confd conf directory (default "/etc/confd")
-  -config-file string
-      the confd config file (default "/etc/confd/confd.toml")
-  -file value
-      the YAML file to watch for changes (only used with -backend=file)
-  -filter string
-      files filter (only used with -backend=file) (default "*")
-  -interval int
-      backend polling interval (default 600)
-  -keep-stage-file
-      keep staged files
-  -log-format string
-      format of log messages (text or json)
-  -log-level string
-      level which confd should log messages
-  -node value
-      list of backend nodes
-  -noop
-      only show pending changes
-  -onetime
-      run once and exit
-  -password string
-      the password to authenticate with (only used with vault and etcd backends)
-  -path string
-      Vault mount path of the auth method (only used with -backend=vault)
-  -prefix string
-      key path prefix
-  -role-id string
-      Vault role-id to use with the AppRole, Kubernetes backends (only used with -backend=vault and either auth-type=app-role or auth-type=kubernetes)
-  -scheme string
-      the backend URI scheme for nodes retrieved from DNS SRV records (http or https) (default "http")
-  -secret-id string
-      Vault secret-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role)
-  -secretsmanager-no-flatten
-      disable JSON flattening, return raw secret string (only used with -backend=secretsmanager)
-  -secretsmanager-version-stage string
-      version stage for Secrets Manager (AWSCURRENT, AWSPREVIOUS, or custom label) (default "AWSCURRENT") (only used with -backend=secretsmanager)
-  -separator string
-      the separator to replace '/' with when looking up keys in the backend, prefixed '/' will also be removed (only used with -backend=redis)
-  -srv-domain string
-      the name of the resource record
-  -srv-record string
-      the SRV record to search for backends nodes. Example: _etcd-client._tcp.example.com
-  -sync-only
-      sync without check_cmd and reload_cmd
-  -table string
-      the name of the DynamoDB table (only used with -backend=dynamodb)
-  -user-id string
-      Vault user-id to use with the app-id backend (only used with -backend=value and auth-type=app-id)
-  -username string
-      the username to authenticate as (only used with vault and etcd backends)
-  -version
-      print version and exit
-  -watch
-      enable watch support
+## Global Flags
+
+These flags are available for all backends:
+
+```
+confd --help
 ```
 
-> The -scheme flag is only used to set the URL scheme for nodes retrieved from DNS SRV records.
+```text
+Usage: confd <command> [flags]
+
+Manage local config files using templates and data from backends
+
+Flags:
+  -h, --help                    Show context-sensitive help.
+      --confdir="/etc/confd"    confd conf directory
+      --config-file="/etc/confd/confd.toml"
+                                confd config file
+      --interval=600            backend polling interval
+      --log-level=""            log level (debug, info, warn, error)
+      --log-format=""           log format (text, json)
+      --noop                    only show pending changes
+      --onetime                 run once and exit
+      --prefix=STRING           key path prefix
+      --sync-only               sync without check_cmd and reload_cmd
+      --watch                   enable watch support
+      --keep-stage-file         keep staged files
+      --srv-domain=STRING       DNS SRV domain
+      --srv-record=STRING       SRV record for backend node discovery
+      --version                 print version and exit
+
+Commands:
+  consul        Use Consul backend
+  etcd          Use etcd backend
+  vault         Use Vault backend
+  redis         Use Redis backend
+  zookeeper     Use Zookeeper backend
+  dynamodb      Use DynamoDB backend
+  ssm           Use AWS SSM Parameter Store backend
+  acm           Use AWS ACM backend
+  secretsmanager Use AWS Secrets Manager backend
+  env           Use environment variables backend
+  file          Use file backend
+
+Run "confd <command> --help" for more information on a command.
+```
+
+## Backend-Specific Flags
+
+Each backend has its own set of flags. Use `confd <backend> --help` to see all available options.
+
+### consul
+
+```bash
+confd consul --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | Consul agent address | `127.0.0.1:8500` |
+| `--scheme` | URI scheme (http or https) | `http` |
+| `--basic-auth` | Use basic authentication | `false` |
+| `--username` | Authentication username | - |
+| `--password` | Authentication password | - |
+| `--client-cert` | Client certificate file | - |
+| `--client-key` | Client key file | - |
+| `--client-ca-keys` | CA certificate file | - |
+
+### etcd
+
+```bash
+confd etcd --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | etcd node addresses (repeatable) | - |
+| `--scheme` | URI scheme (http or https) | `http` |
+| `--basic-auth` | Use basic authentication | `false` |
+| `--username` | Authentication username | - |
+| `--password` | Authentication password | - |
+| `--auth-token` | Bearer token for authentication | - |
+| `--client-cert` | Client certificate file | - |
+| `--client-key` | Client key file | - |
+| `--client-ca-keys` | CA certificate file | - |
+| `--client-insecure` | Skip TLS certificate verification | `false` |
+
+### vault
+
+```bash
+confd vault --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | Vault server address | - |
+| `--auth-type` | Auth method (token, app-id, app-role, kubernetes) | - |
+| `--auth-token` | Vault auth token ($VAULT_TOKEN) | - |
+| `--app-id` | App ID for app-id auth | - |
+| `--user-id` | User ID for app-id auth | - |
+| `--role-id` | Role ID for app-role/kubernetes auth | - |
+| `--secret-id` | Secret ID for app-role auth | - |
+| `--path` | Auth mount path | - |
+| `--username` | Username for userpass auth | - |
+| `--password` | Password for userpass auth | - |
+| `--client-cert` | Client certificate file | - |
+| `--client-key` | Client key file | - |
+| `--client-ca-keys` | CA certificate file | - |
+
+### redis
+
+```bash
+confd redis --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | Redis server address | - |
+| `--password` | Redis password | - |
+| `--separator` | Key separator (replaces `/`) | `/` |
+
+### zookeeper
+
+```bash
+confd zookeeper --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | ZooKeeper server addresses (repeatable) | - |
+
+### dynamodb
+
+```bash
+confd dynamodb --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--table` | DynamoDB table name | Required |
+
+### ssm
+
+```bash
+confd ssm --help
+```
+
+No backend-specific flags. Uses AWS SDK credential chain.
+
+### secretsmanager
+
+```bash
+confd secretsmanager --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--secretsmanager-version-stage` | Version stage (AWSCURRENT, AWSPREVIOUS) | `AWSCURRENT` |
+| `--secretsmanager-no-flatten` | Disable JSON flattening | `false` |
+
+### acm
+
+```bash
+confd acm --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--acm-export-private-key` | Enable private key export | `false` |
+
+### env
+
+```bash
+confd env --help
+```
+
+No backend-specific flags.
+
+### file
+
+```bash
+confd file --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--file` | Path to YAML/JSON file or directory (repeatable) | Required |
+| `--filter` | Glob pattern to filter files | `*` |
+
+## Examples
+
+### One-time run with etcd
+
+```bash
+confd etcd --node http://127.0.0.1:2379 --onetime
+```
+
+### Watch mode with Consul
+
+```bash
+confd consul --node 127.0.0.1:8500 --watch
+```
+
+### Interval polling with Vault
+
+```bash
+confd vault --node http://127.0.0.1:8200 \
+  --auth-type token --auth-token s.XXX \
+  --interval 60
+```
+
+### Environment variables backend
+
+```bash
+confd env --onetime
+```
+
+### File backend with watch
+
+```bash
+confd file --file /etc/myapp/config.yaml --watch
+```
+
+## Environment Variables
+
+Global configuration can also be set via environment variables with the `CONFD_` prefix:
+
+| Variable | Description |
+|----------|-------------|
+| `CONFD_CONFDIR` | Configuration directory |
+| `CONFD_INTERVAL` | Polling interval |
+| `CONFD_LOG_LEVEL` | Log level |
+| `CONFD_PREFIX` | Key prefix |
+
+Backend-specific environment variables are documented in each backend's README.

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -1,7 +1,7 @@
 # Configuration Guide
 
 The confd configuration file is written in [TOML](https://github.com/mojombo/toml)
-and loaded from `/etc/confd/confd.toml` by default. You can specify the config file via the `-config-file` command line flag.
+and loaded from `/etc/confd/confd.toml` by default. You can specify the config file via the `--config-file` command line flag.
 
 > Note: You can use confd without a configuration file. See [Command Line Flags](command-line-flags.md).
 
@@ -25,18 +25,18 @@ Optional:
 * `watch` (bool) - Enable watch support.
 * `auth_token` (string) - Auth bearer token to use.
 * `auth_type` (string) - Vault auth backend type to use.
-* `basic_auth` (bool) - Use Basic Auth to authenticate (only used with -backend=consul and -backend=etcd).
-* `table` (string) - The name of the DynamoDB table (only used with -backend=dynamodb).
-* `separator` (string) - The separator to replace '/' with when looking up keys in the backend, prefixed '/' will also be removed (only used with -backend=redis)
-* `username` (string) - The username to authenticate as (only used with vault and etcd backends).
-* `password` (string) - The password to authenticate with (only used with vault and etcd backends).
-* `app_id` (string) - Vault app-id to use with the app-id backend (only used with -backend=vault and auth-type=app-id).
-* `user_id` (string) - Vault user-id to use with the app-id backend (only used with -backend=value and auth-type=app-id).
-* `role_id` (string) - Vault role-id to use with the AppRole, Kubernetes backends (only used with -backend=vault and either auth-type=app-role or auth-type=kubernetes).
-* `secret_id` (string) - Vault secret-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role).
-* `file` (array of strings) - The YAML file to watch for changes (only used with -backend=file).
-* `filter` (string) - Files filter (only used with -backend=file) (default "*").
-* `path` (string) - Vault mount path of the auth method (only used with -backend=vault).
+* `basic_auth` (bool) - Use Basic Auth to authenticate (consul and etcd backends only).
+* `table` (string) - The name of the DynamoDB table (dynamodb backend only).
+* `separator` (string) - The separator to replace '/' with when looking up keys in the backend, prefixed '/' will also be removed (redis backend only).
+* `username` (string) - The username to authenticate as (vault and etcd backends only).
+* `password` (string) - The password to authenticate with (vault and etcd backends only).
+* `app_id` (string) - Vault app-id to use with the app-id backend (vault backend with auth-type=app-id only).
+* `user_id` (string) - Vault user-id to use with the app-id backend (vault backend with auth-type=app-id only).
+* `role_id` (string) - Vault role-id to use with the AppRole, Kubernetes backends (vault backend with auth-type=app-role or auth-type=kubernetes only).
+* `secret_id` (string) - Vault secret-id to use with the AppRole backend (vault backend with auth-type=app-role only).
+* `file` (array of strings) - The YAML file to watch for changes (file backend only).
+* `filter` (string) - Files filter (file backend only) (default "*").
+* `path` (string) - Vault mount path of the auth method (vault backend only).
 
 Example:
 

--- a/docs/dns-srv-records.md
+++ b/docs/dns-srv-records.md
@@ -1,6 +1,6 @@
 # DNS SRV Records
 
-SRV records can be used to declare the backend nodes; just use the `-srv-domain` flag.
+SRV records can be used to declare the backend nodes; just use the `--srv-domain` flag.
 
 ## Examples
 
@@ -19,7 +19,7 @@ _etcd._tcp.confd.io.	300	IN	SRV	1 100 4001 etcd.confd.io.
 -
 
 ```
-confd -backend etcd -srv-domain confd.io
+confd etcd --srv-domain confd.io
 ```
 
 ### consul
@@ -37,15 +37,15 @@ _consul._tcp.confd.io.	300	IN	SRV	1 100 8500 consul.confd.io.
 -
 
 ```
-confd -backend consul -srv-domain confd.io
+confd consul --srv-domain confd.io
 ```
 
 ## The backend scheme
 
-By default the `scheme` is set to http; change it with the `-scheme` flag.
+By default the `scheme` is set to http; change it with the `--scheme` flag.
 
 ```
-confd -scheme https -srv-domain confd.io
+confd etcd --scheme https --srv-domain confd.io
 ```
 
 Both the SRV domain and scheme can be configured in the confd configuration file. See the [Configuration Guide](configuration-guide.md) for more details.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,7 +42,7 @@ Download the appropriate `.zip` file from the [releases page](https://github.com
 ARG CONFD_VERSION=0.32.0
 RUN CONFD_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && curl -SL "https://github.com/abtreece/confd/releases/download/v${CONFD_VERSION}/confd-v${CONFD_VERSION}-linux-${CONFD_ARCH}.tar.gz" | tar -xz -C /usr/local/bin/ \
-    && confd -version
+    && confd --version
 ```
 
 #### Building from Source

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,14 +1,14 @@
 # Logging
 
-confd logs everything to stdout. You can control the types of messages that get printed by using the `-log-level` flag and corresponding configuration file settings. See the [Configuration Guide](configuration-guide.md) for more details.
+confd logs everything to stdout. You can control the types of messages that get printed by using the `--log-level` flag and corresponding configuration file settings. See the [Configuration Guide](configuration-guide.md) for more details.
 
 ## Log Levels
 
-Use the `-log-level` flag to set the verbosity. Valid levels are: `panic`, `fatal`, `error`, `warn`, `info`, and `debug`.
+Use the `--log-level` flag to set the verbosity. Valid levels are: `panic`, `fatal`, `error`, `warn`, `info`, and `debug`.
 
 ## Log Formats
 
-confd supports two log formats, controlled by the `-log-format` flag:
+confd supports two log formats, controlled by the `--log-format` flag:
 
 ### Text Format (default)
 
@@ -24,10 +24,10 @@ The default text format includes timestamp, hostname, process name, PID, level, 
 
 ### JSON Format
 
-Use `-log-format=json` for structured JSON output, which is easier to parse with log indexing solutions (ELK, Splunk, etc.):
+Use `--log-format=json` for structured JSON output, which is easier to parse with log indexing solutions (ELK, Splunk, etc.):
 
 ```bash
-confd -log-format=json -backend=env -onetime
+confd env --log-format=json --onetime
 ```
 
 ```json

--- a/docs/noop-mode.md
+++ b/docs/noop-mode.md
@@ -7,7 +7,7 @@ When in noop mode target configuration files will not be modified.
 ### commandline flag
 
 ```
-confd -noop
+confd env --noop
 ```
 
 ### configuration file
@@ -19,7 +19,7 @@ noop = true
 ### Example
 
 ```
-confd -onetime -noop
+confd env --onetime --noop
 ```
 
 -

--- a/docs/tomcat-sample.md
+++ b/docs/tomcat-sample.md
@@ -80,5 +80,5 @@ reload_cmd = "/usr/local/tomcat/bin/catalina.sh stop -force && /usr/local/tomcat
 Finally we need to replace in all above templates ```catalina.sh start``` by ```catalina_start.sh start```
 
 ## test it
-Follow conf documentation and test it calling ```confd -onetime``` or you try the complete sample in a Docker and/or Vagrant environment [here](https://github.com/muenchhausen/tomcat-confd)
+Follow confd documentation and test it calling ```confd <backend> --onetime``` (e.g., `confd etcd --node http://127.0.0.1:2379 --onetime`) or you try the complete sample in a Docker and/or Vagrant environment [here](https://github.com/muenchhausen/tomcat-confd)
 

--- a/pkg/backends/acm/README.md
+++ b/pkg/backends/acm/README.md
@@ -1,0 +1,227 @@
+# ACM Backend
+
+The ACM backend enables confd to retrieve SSL/TLS certificates from [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/). It can retrieve certificate bodies, certificate chains, and optionally export private keys for certificates that support it.
+
+## Configuration
+
+The ACM backend uses the [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/) credential chain, which checks credentials in the following order:
+
+1. Environment variables
+2. Shared credentials file (`~/.aws/credentials`)
+3. IAM role for EC2/ECS/EKS
+
+### Environment Variables
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_REGION=us-east-1
+```
+
+### IAM Role for EC2/ECS/EKS
+
+When running on AWS compute (EC2, ECS, EKS), confd can use the instance/task role automatically. No credential configuration is needed.
+
+The region is automatically detected from EC2 instance metadata if `AWS_REGION` is not set.
+
+### Required IAM Permissions
+
+For retrieving certificates (without private key):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "acm:GetCertificate",
+      "Resource": "arn:aws:acm:*:*:certificate/*"
+    }
+  ]
+}
+```
+
+For exporting certificates with private keys:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "acm:ExportCertificate",
+      "Resource": "arn:aws:acm:*:*:certificate/*"
+    }
+  ]
+}
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--export-private-key` | Enable private key export | `false` |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` | AWS region (required) |
+| `AWS_PROFILE` | Named profile from credentials file |
+| `ACM_PASSPHRASE` | Passphrase for private key encryption (required with `--export-private-key`) |
+| `ACM_LOCAL` | Enable local endpoint (for testing) |
+| `ACM_ENDPOINT_URL` | Custom ACM endpoint URL |
+
+## Certificate Identification
+
+Certificates are identified by their ARN. Use the full ARN as the key:
+
+```
+arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
+```
+
+## Retrieved Keys
+
+For each certificate ARN, the following keys are available:
+
+| Key Suffix | Description | Always Available |
+|------------|-------------|------------------|
+| (none) | Certificate body (PEM) | Yes |
+| `_chain` | Certificate chain (PEM) | Yes |
+| `_private_key` | Encrypted private key (PKCS#8 PEM) | Only with export enabled |
+
+## Basic Example
+
+Create template resource (`/etc/confd/conf.d/certificate.toml`):
+
+```toml
+[template]
+src = "certificate.tmpl"
+dest = "/etc/ssl/certs/app-cert.pem"
+mode = "0644"
+keys = [
+  "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012",
+]
+```
+
+Create template (`/etc/confd/templates/certificate.tmpl`):
+
+```
+{{getv "/arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"}}
+```
+
+Run confd:
+
+```bash
+confd acm --onetime
+```
+
+## Advanced Example
+
+### Retrieving Certificate with Chain
+
+Template for full certificate bundle:
+
+```toml
+[template]
+src = "fullchain.tmpl"
+dest = "/etc/ssl/certs/fullchain.pem"
+mode = "0644"
+keys = [
+  "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012",
+]
+```
+
+Template (`/etc/confd/templates/fullchain.tmpl`):
+
+```
+{{getv "/arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"}}
+{{getv "/arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012_chain"}}
+```
+
+### Exporting Private Keys
+
+Private key export is supported for:
+- AWS Private CA issued certificates
+- Imported certificates
+- Public certificates issued after June 17, 2025 with export option enabled
+
+```bash
+export ACM_PASSPHRASE="your-secure-passphrase"
+confd acm --export-private-key --onetime
+```
+
+Template for private key (`/etc/confd/templates/private-key.tmpl`):
+
+```
+{{getv "/arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012_private_key"}}
+```
+
+**Note**: The private key is returned encrypted with the passphrase. To decrypt:
+
+```bash
+openssl rsa -in encrypted_key.pem -out decrypted_key.pem
+```
+
+### Multiple Certificates
+
+Template resource for multiple certificates:
+
+```toml
+[template]
+src = "nginx-ssl.conf.tmpl"
+dest = "/etc/nginx/ssl.conf"
+keys = [
+  "arn:aws:acm:us-east-1:123456789012:certificate/cert-1",
+  "arn:aws:acm:us-east-1:123456789012:certificate/cert-2",
+]
+```
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  serviceAccountName: confd-sa  # With IRSA configured
+  containers:
+  - name: myapp
+    env:
+    - name: ACM_PASSPHRASE
+      valueFrom:
+        secretKeyRef:
+          name: acm-secrets
+          key: passphrase
+    command:
+    - confd
+    - acm
+    - --export-private-key
+    - --interval=3600
+    volumeMounts:
+    - name: certs
+      mountPath: /etc/ssl/certs
+  volumes:
+  - name: certs
+    emptyDir: {}
+```
+
+## Watch Mode Support
+
+Watch mode is **not supported** for the ACM backend. Use interval mode (`--interval`) for periodic polling.
+
+```bash
+confd acm --interval 3600
+```
+
+Certificates typically don't change frequently, so longer intervals (e.g., hourly) are usually sufficient.
+
+## Security Considerations
+
+1. **Private Key Protection**: When exporting private keys, ensure the passphrase is stored securely (e.g., in Kubernetes Secrets or AWS Secrets Manager)
+2. **IAM Permissions**: Use least-privilege IAM policies, restricting access to specific certificate ARNs
+3. **File Permissions**: Set restrictive file modes for certificate files, especially private keys (`mode = "0600"`)
+4. **Encrypted Private Keys**: The exported private key is encrypted; decrypt only when necessary

--- a/pkg/backends/consul/README.md
+++ b/pkg/backends/consul/README.md
@@ -1,0 +1,191 @@
+# Consul Backend
+
+The Consul backend enables confd to retrieve configuration data from [HashiCorp Consul](https://www.consul.io/)'s key-value store.
+
+## Configuration
+
+### Basic Connection
+
+Connect to Consul without authentication:
+
+```bash
+confd consul --node 127.0.0.1:8500 --onetime
+```
+
+### Authentication
+
+#### HTTP Basic Auth
+
+```bash
+confd consul --node 127.0.0.1:8500 \
+  --basic-auth --username admin --password secret --onetime
+```
+
+#### ACL Token
+
+Set the `CONSUL_HTTP_TOKEN` environment variable:
+
+```bash
+export CONSUL_HTTP_TOKEN=your-acl-token
+confd consul --node 127.0.0.1:8500 --onetime
+```
+
+#### TLS Client Certificates
+
+```bash
+confd consul --node 127.0.0.1:8501 \
+  --scheme https \
+  --client-cert /path/to/client.crt \
+  --client-key /path/to/client.key \
+  --client-ca-keys /path/to/ca.crt --onetime
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | Consul agent address | `127.0.0.1:8500` |
+| `--scheme` | HTTP scheme (`http` or `https`) | `http` |
+| `--basic-auth` | Enable HTTP basic authentication | `false` |
+| `--username` | Username for basic auth | - |
+| `--password` | Password for basic auth | - |
+| `--client-cert` | Path to client certificate | - |
+| `--client-key` | Path to client private key | - |
+| `--client-ca-keys` | Path to CA certificate | - |
+
+### Environment Variables
+
+Consul's standard environment variables are also supported:
+
+| Variable | Description |
+|----------|-------------|
+| `CONSUL_HTTP_ADDR` | Consul agent address |
+| `CONSUL_HTTP_TOKEN` | ACL token |
+| `CONSUL_HTTP_SSL` | Enable HTTPS |
+| `CONSUL_CACERT` | CA certificate path |
+| `CONSUL_CLIENT_CERT` | Client certificate path |
+| `CONSUL_CLIENT_KEY` | Client key path |
+
+## Basic Example
+
+Add keys to Consul:
+
+```bash
+consul kv put myapp/database/url "db.example.com"
+consul kv put myapp/database/user "admin"
+consul kv put myapp/database/password "secret123"
+```
+
+Or using the HTTP API:
+
+```bash
+curl -X PUT -d 'db.example.com' http://localhost:8500/v1/kv/myapp/database/url
+curl -X PUT -d 'admin' http://localhost:8500/v1/kv/myapp/database/user
+curl -X PUT -d 'secret123' http://localhost:8500/v1/kv/myapp/database/password
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd consul --node 127.0.0.1:8500 --onetime
+```
+
+## Advanced Example
+
+### Using ACL Tokens
+
+Create a policy for confd:
+
+```hcl
+# confd-policy.hcl
+key_prefix "myapp/" {
+  policy = "read"
+}
+```
+
+```bash
+# Create the policy
+consul acl policy create -name confd -rules @confd-policy.hcl
+
+# Create a token
+consul acl token create -policy-name confd -description "confd token"
+```
+
+Use the token:
+
+```bash
+export CONSUL_HTTP_TOKEN=<token-secret-id>
+confd consul --node 127.0.0.1:8500 --watch
+```
+
+### TLS Configuration
+
+```bash
+confd consul --node consul.example.com:8501 \
+  --scheme https \
+  --client-ca-keys /etc/consul.d/ca.pem \
+  --client-cert /etc/consul.d/client.pem \
+  --client-key /etc/consul.d/client-key.pem \
+  --watch
+```
+
+### Kubernetes with Consul Connect
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+  annotations:
+    consul.hashicorp.com/connect-inject: "true"
+spec:
+  containers:
+  - name: myapp
+    env:
+    - name: CONSUL_HTTP_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: consul-token
+          key: token
+    command:
+    - confd
+    - consul
+    - --node=127.0.0.1:8500
+    - --watch
+```
+
+## Watch Mode Support
+
+Watch mode **is supported** for the Consul backend. confd uses Consul's blocking queries for efficient change detection.
+
+```bash
+confd consul --node 127.0.0.1:8500 --watch
+```
+
+Consul blocking queries long-poll the server, returning immediately when data changes. This provides near-real-time updates without constant polling.
+
+## Connection Notes
+
+- Only the first `--node` is used; Consul client does not support multiple nodes
+- Use a local Consul agent or load balancer for high availability
+- Consul's default HTTP timeout applies to blocking queries

--- a/pkg/backends/dynamodb/README.md
+++ b/pkg/backends/dynamodb/README.md
@@ -1,0 +1,203 @@
+# DynamoDB Backend
+
+The DynamoDB backend enables confd to retrieve configuration data from [Amazon DynamoDB](https://aws.amazon.com/dynamodb/).
+
+## Configuration
+
+The DynamoDB backend uses the [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/) credential chain, which checks credentials in the following order:
+
+1. Environment variables
+2. Shared credentials file (`~/.aws/credentials`)
+3. IAM role for EC2/ECS/EKS
+
+### Environment Variables
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_REGION=us-east-1
+```
+
+### IAM Role for EC2/ECS/EKS
+
+When running on AWS compute (EC2, ECS, EKS), confd can use the instance/task role automatically. No credential configuration is needed.
+
+### Required IAM Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:Scan",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/confd-config"
+    }
+  ]
+}
+```
+
+## Table Schema
+
+The DynamoDB table must have the following schema:
+
+| Attribute | Type | Key |
+|-----------|------|-----|
+| `key` | String (S) | Partition Key (HASH) |
+| `value` | String (S) | - |
+
+Create the table:
+
+```bash
+aws dynamodb create-table \
+  --region us-east-1 \
+  --table-name confd-config \
+  --attribute-definitions AttributeName=key,AttributeType=S \
+  --key-schema AttributeName=key,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--table` | DynamoDB table name | Required |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` | AWS region |
+| `AWS_PROFILE` | Named profile from credentials file |
+| `DYNAMODB_LOCAL` | Enable local endpoint (for testing) |
+| `DYNAMODB_ENDPOINT_URL` | Custom DynamoDB endpoint URL |
+
+## Basic Example
+
+Add items to DynamoDB:
+
+```bash
+aws dynamodb put-item --table-name confd-config \
+  --item '{"key": {"S": "/myapp/database/url"}, "value": {"S": "db.example.com"}}'
+
+aws dynamodb put-item --table-name confd-config \
+  --item '{"key": {"S": "/myapp/database/user"}, "value": {"S": "admin"}}'
+
+aws dynamodb put-item --table-name confd-config \
+  --item '{"key": {"S": "/myapp/database/password"}, "value": {"S": "secret123"}}'
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd dynamodb --table confd-config --onetime
+```
+
+## Advanced Example
+
+### Using Prefix-Based Retrieval
+
+confd can retrieve all keys with a common prefix:
+
+```bash
+# Store hierarchical config
+aws dynamodb put-item --table-name confd-config \
+  --item '{"key": {"S": "/production/api/host"}, "value": {"S": "api.example.com"}}'
+aws dynamodb put-item --table-name confd-config \
+  --item '{"key": {"S": "/production/api/port"}, "value": {"S": "443"}}'
+aws dynamodb put-item --table-name confd-config \
+  --item '{"key": {"S": "/production/db/host"}, "value": {"S": "db.example.com"}}'
+```
+
+Template resource:
+
+```toml
+[template]
+src = "app.conf.tmpl"
+dest = "/etc/app/config.conf"
+keys = [
+  "/production",
+]
+```
+
+### Local Development with DynamoDB Local
+
+```bash
+# Start DynamoDB Local
+docker run -p 8000:8000 amazon/dynamodb-local
+
+# Create table
+aws dynamodb create-table \
+  --endpoint-url http://localhost:8000 \
+  --table-name confd-config \
+  --attribute-definitions AttributeName=key,AttributeType=S \
+  --key-schema AttributeName=key,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+
+# Run confd with local endpoint
+export DYNAMODB_LOCAL=true
+export DYNAMODB_ENDPOINT_URL=http://localhost:8000
+export AWS_ACCESS_KEY_ID=dummy
+export AWS_SECRET_ACCESS_KEY=dummy
+export AWS_REGION=us-east-1
+
+confd dynamodb --table confd-config --onetime
+```
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  serviceAccountName: confd-sa  # With IRSA configured
+  containers:
+  - name: myapp
+    command:
+    - confd
+    - dynamodb
+    - --table=confd-config
+    - --interval=300
+```
+
+## Watch Mode Support
+
+Watch mode is **not supported** for the DynamoDB backend. Use interval mode (`--interval`) for periodic polling.
+
+```bash
+confd dynamodb --table confd-config --interval 60
+```
+
+## Data Retrieval Behavior
+
+1. **Exact key lookup**: First attempts to get the item by exact key match
+2. **Prefix scan**: If not found, scans for items with keys starting with the specified prefix
+3. **Value type**: Only string (`S`) type values are supported; other types are skipped with a warning

--- a/pkg/backends/env/README.md
+++ b/pkg/backends/env/README.md
@@ -1,0 +1,143 @@
+# Environment Variables Backend
+
+The env backend enables confd to retrieve configuration data from environment variables. This is the simplest backend, requiring no external services or authentication.
+
+## Configuration
+
+No configuration is required. The env backend reads directly from the process environment.
+
+## Key Mapping
+
+Environment variable names are mapped to confd keys using the following transformation:
+
+| confd key | Environment variable |
+|-----------|---------------------|
+| `/myapp/database/url` | `MYAPP_DATABASE_URL` |
+| `/myapp/database/user` | `MYAPP_DATABASE_USER` |
+| `/config/api/key` | `CONFIG_API_KEY` |
+
+The transformation rules:
+1. Remove the leading `/`
+2. Replace `/` with `_`
+3. Convert to uppercase
+
+When confd retrieves values, it reverses this transformation to present keys in the standard `/path/format`.
+
+## Options
+
+The env backend has no backend-specific flags.
+
+## Basic Example
+
+Set environment variables:
+
+```bash
+export MYAPP_DATABASE_URL=db.example.com
+export MYAPP_DATABASE_USER=admin
+export MYAPP_DATABASE_PASSWORD=secret123
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd env --onetime
+```
+
+## Advanced Example
+
+Using with Docker or Kubernetes:
+
+**Docker:**
+
+```bash
+docker run -e MYAPP_DATABASE_URL=db.example.com \
+           -e MYAPP_DATABASE_USER=admin \
+           -v /etc/confd:/etc/confd \
+           myapp-with-confd
+```
+
+**Kubernetes ConfigMap:**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp-config
+data:
+  MYAPP_DATABASE_URL: "db.example.com"
+  MYAPP_DATABASE_USER: "admin"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+  - name: myapp
+    envFrom:
+    - configMapRef:
+        name: myapp-config
+```
+
+**Kubernetes Secrets:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myapp-secrets
+type: Opaque
+stringData:
+  MYAPP_DATABASE_PASSWORD: "secret123"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+  - name: myapp
+    envFrom:
+    - secretRef:
+        name: myapp-secrets
+```
+
+## Watch Mode Support
+
+Watch mode is **not supported** for the env backend. Environment variables are only read at startup or when using interval mode.
+
+For periodic updates:
+
+```bash
+confd env --interval 60
+```
+
+## Use Cases
+
+The env backend is ideal for:
+
+- **12-factor applications** following environment-based configuration
+- **Container deployments** where config is injected via environment
+- **Local development** with simple configuration needs
+- **CI/CD pipelines** where secrets are passed as environment variables
+- **Serverless functions** that receive configuration via environment

--- a/pkg/backends/etcd/README.md
+++ b/pkg/backends/etcd/README.md
@@ -1,0 +1,169 @@
+# etcd Backend
+
+The etcd backend enables confd to retrieve configuration data from [etcd](https://etcd.io/), a distributed key-value store. This backend uses the etcd v3 API.
+
+## Configuration
+
+### Basic Connection
+
+Connect to etcd without authentication:
+
+```bash
+confd etcd --node http://127.0.0.1:2379 --onetime
+```
+
+Multiple nodes for high availability:
+
+```bash
+confd etcd \
+  --node http://etcd1.example.com:2379 \
+  --node http://etcd2.example.com:2379 \
+  --node http://etcd3.example.com:2379 --onetime
+```
+
+### Authentication
+
+#### Username/Password
+
+```bash
+confd etcd --node http://127.0.0.1:2379 \
+  --basic-auth --username admin --password secret --onetime
+```
+
+#### TLS Client Certificates
+
+```bash
+confd etcd --node https://127.0.0.1:2379 \
+  --client-cert /path/to/client.crt \
+  --client-key /path/to/client.key \
+  --client-ca-keys /path/to/ca.crt --onetime
+```
+
+#### TLS with Authentication
+
+```bash
+confd etcd --node https://127.0.0.1:2379 \
+  --client-cert /path/to/client.crt \
+  --client-key /path/to/client.key \
+  --client-ca-keys /path/to/ca.crt \
+  --basic-auth --username admin --password secret --onetime
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | etcd node address (can be specified multiple times) | - |
+| `--basic-auth` | Enable basic authentication | `false` |
+| `--username` | Username for basic auth | - |
+| `--password` | Password for basic auth | - |
+| `--client-cert` | Path to client certificate | - |
+| `--client-key` | Path to client private key | - |
+| `--client-ca-keys` | Path to CA certificate | - |
+| `--scheme` | URI scheme (http or https) | `http` |
+| `--client-insecure` | Skip TLS certificate verification | `false` |
+
+## Basic Example
+
+Add keys to etcd:
+
+```bash
+etcdctl put /myapp/database/url "db.example.com"
+etcdctl put /myapp/database/user "admin"
+etcdctl put /myapp/database/password "secret123"
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd etcd --node http://127.0.0.1:2379 --onetime
+```
+
+## Advanced Example
+
+### Using DNS SRV Records
+
+Discover etcd nodes via DNS SRV records:
+
+```bash
+confd etcd \
+  --srv-record _etcd-client._tcp.example.com \
+  --scheme https --onetime
+```
+
+### Watch Mode with TLS
+
+```bash
+confd etcd \
+  --node https://etcd.example.com:2379 \
+  --client-ca-keys /etc/ssl/certs/etcd-ca.crt \
+  --watch
+```
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+  - name: myapp
+    env:
+    - name: ETCD_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: etcd-credentials
+          key: username
+    - name: ETCD_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: etcd-credentials
+          key: password
+    command:
+    - confd
+    - etcd
+    - --node=http://etcd.default.svc:2379
+    - --basic-auth
+    - --username=$(ETCD_USERNAME)
+    - --password=$(ETCD_PASSWORD)
+    - --watch
+```
+
+## Watch Mode Support
+
+Watch mode **is supported** for the etcd backend. confd uses etcd's native watch API for efficient real-time updates.
+
+```bash
+confd etcd --node http://127.0.0.1:2379 --watch
+```
+
+When keys change in etcd, confd immediately detects the change and re-renders affected templates.
+
+## Connection Behavior
+
+- **Dial timeout**: 5 seconds
+- **Keep-alive**: 10 seconds interval, 3 seconds timeout
+- **Transaction limit**: 128 operations per transaction (etcd v3 default)
+- **Automatic reconnection**: Watch connections automatically reconnect after disconnection

--- a/pkg/backends/file/README.md
+++ b/pkg/backends/file/README.md
@@ -1,0 +1,193 @@
+# File Backend
+
+The file backend enables confd to retrieve configuration data from local YAML or JSON files. This is useful for local development, testing, or deployments where configuration is mounted from ConfigMaps or secrets.
+
+## Configuration
+
+No authentication is required. The file backend reads files from the local filesystem.
+
+## Supported File Formats
+
+- **YAML** (`.yaml`, `.yml`, or no extension)
+- **JSON** (`.json`)
+
+Nested structures are flattened to key paths:
+
+```yaml
+# config.yaml
+myapp:
+  database:
+    url: db.example.com
+    user: admin
+```
+
+Becomes:
+- `/myapp/database/url` = `db.example.com`
+- `/myapp/database/user` = `admin`
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--file` | Path to file or directory (can be specified multiple times) | Required |
+| `--filter` | Glob pattern to filter files | `*` |
+
+## Basic Example
+
+Create a YAML configuration file (`/etc/myapp/values.yaml`):
+
+```yaml
+myapp:
+  database:
+    url: db.example.com
+    user: admin
+    password: secret123
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd file --file /etc/myapp/values.yaml --onetime
+```
+
+## Advanced Example
+
+### Multiple Files
+
+Read from multiple configuration files:
+
+```bash
+confd file \
+  --file /etc/myapp/defaults.yaml \
+  --file /etc/myapp/overrides.yaml --onetime
+```
+
+### Directory with Filter
+
+Read all YAML files from a directory:
+
+```bash
+confd file \
+  --file /etc/myapp/config.d/ \
+  --filter "*.yaml" --onetime
+```
+
+### JSON Configuration
+
+```json
+{
+  "myapp": {
+    "database": {
+      "url": "db.example.com",
+      "user": "admin"
+    },
+    "cache": {
+      "host": "redis.example.com",
+      "port": 6379
+    }
+  }
+}
+```
+
+### Kubernetes ConfigMap Volume
+
+Mount a ConfigMap as a file:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp-config
+data:
+  config.yaml: |
+    myapp:
+      database:
+        url: db.example.com
+        user: admin
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+  - name: myapp
+    volumeMounts:
+    - name: config
+      mountPath: /etc/myapp
+  volumes:
+  - name: config
+    configMap:
+      name: myapp-config
+```
+
+## Watch Mode Support
+
+Watch mode **is supported** for the file backend. confd uses filesystem notifications to detect changes.
+
+```bash
+confd file --file /etc/myapp/values.yaml --watch
+```
+
+When files are modified, created, or deleted, confd automatically re-renders templates.
+
+## Data Types
+
+The file backend handles various YAML/JSON data types:
+
+| YAML/JSON Type | confd Value |
+|----------------|-------------|
+| String | As-is |
+| Integer | String representation |
+| Float | String representation |
+| Boolean | `true` or `false` |
+| Array | Indexed keys (`/path/0`, `/path/1`, etc.) |
+| Object | Nested keys |
+
+Example with arrays:
+
+```yaml
+myapp:
+  servers:
+    - host: server1.example.com
+      port: 8080
+    - host: server2.example.com
+      port: 8081
+```
+
+Access in templates:
+
+```
+{{range gets "/myapp/servers/*"}}
+server {{.Key}} = {{.Value}}
+{{end}}
+```
+
+## Use Cases
+
+The file backend is ideal for:
+
+- **Local development** without running external services
+- **Testing** confd templates before deployment
+- **Kubernetes** deployments with ConfigMaps/Secrets mounted as files
+- **Static configuration** that doesn't need a key-value store

--- a/pkg/backends/redis/README.md
+++ b/pkg/backends/redis/README.md
@@ -1,0 +1,207 @@
+# Redis Backend
+
+The Redis backend enables confd to retrieve configuration data from [Redis](https://redis.io/). It supports string keys, hash fields, and pattern-based key retrieval.
+
+## Configuration
+
+### Basic Connection
+
+Connect to Redis without authentication:
+
+```bash
+confd redis --node 127.0.0.1:6379 --onetime
+```
+
+### Authentication
+
+#### Password
+
+```bash
+confd redis --node 127.0.0.1:6379 --password secret --onetime
+```
+
+Or via environment variable:
+
+```bash
+export REDIS_PASSWORD=secret
+confd redis --node 127.0.0.1:6379 --onetime
+```
+
+### Database Selection
+
+Specify a database number (default is 0):
+
+```bash
+confd redis --node 127.0.0.1:6379/4 --onetime
+```
+
+### Unix Socket
+
+Connect via Unix socket:
+
+```bash
+confd redis --node /var/run/redis/redis.sock --onetime
+```
+
+### Key Separator
+
+By default, confd uses `/` as the key separator. Use `--separator` to change this:
+
+```bash
+confd redis --node 127.0.0.1:6379 --separator : --onetime
+```
+
+This transforms `/myapp/database/url` to `myapp:database:url` when querying Redis.
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | Redis server address (host:port or socket path) | - |
+| `--password` | Redis password | - |
+| `--separator` | Character to replace `/` in keys | `/` |
+
+## Data Types
+
+The Redis backend supports multiple data types:
+
+| Redis Type | confd Behavior |
+|------------|----------------|
+| String | Returns value directly |
+| Hash | Returns all fields as nested keys |
+| Keys (pattern) | Scans matching keys |
+
+### String Keys
+
+```bash
+redis-cli SET /myapp/database/url "db.example.com"
+```
+
+Access as `/myapp/database/url`.
+
+### Hash Fields
+
+```bash
+redis-cli HSET /myapp/database url "db.example.com" user "admin" password "secret"
+```
+
+Access fields as `/myapp/database/url`, `/myapp/database/user`, etc.
+
+## Basic Example
+
+Set keys in Redis:
+
+```bash
+redis-cli SET /myapp/database/url "db.example.com"
+redis-cli SET /myapp/database/user "admin"
+redis-cli SET /myapp/database/password "secret123"
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd redis --node 127.0.0.1:6379 --onetime
+```
+
+## Advanced Example
+
+### Using Hash for Grouped Config
+
+Store related config in a hash:
+
+```bash
+redis-cli HSET /myapp/database url "db.example.com" user "admin" password "secret"
+redis-cli HSET /myapp/cache host "redis.example.com" port "6379"
+```
+
+Template:
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+
+[cache]
+host = {{getv "/myapp/cache/host"}}
+port = {{getv "/myapp/cache/port"}}
+```
+
+### Using Custom Separator
+
+If your Redis keys use `:` as separator:
+
+```bash
+redis-cli SET myapp:database:url "db.example.com"
+```
+
+```bash
+confd redis --node 127.0.0.1:6379 --separator : --onetime
+```
+
+confd will transform `/myapp/database/url` to `myapp:database:url`.
+
+### Redis Sentinel (Manual)
+
+Connect to a Redis instance behind Sentinel by specifying the master's address:
+
+```bash
+# Get master address from Sentinel
+redis-cli -h sentinel1.example.com -p 26379 SENTINEL get-master-addr-by-name mymaster
+
+# Use that address with confd
+confd redis --node <master-ip>:<master-port> --watch
+```
+
+## Watch Mode Support
+
+Watch mode **is supported** for the Redis backend. confd uses Redis keyspace notifications via PubSub.
+
+```bash
+confd redis --node 127.0.0.1:6379 --watch
+```
+
+### Enable Keyspace Notifications
+
+Redis must be configured to emit keyspace notifications:
+
+```bash
+redis-cli CONFIG SET notify-keyspace-events AKE
+```
+
+Or in `redis.conf`:
+
+```
+notify-keyspace-events AKE
+```
+
+- `A` - Alias for all events
+- `K` - Keyspace events
+- `E` - Keyevent events
+
+confd watches for these events: `set`, `del`, `append`, `rename_from`, `rename_to`, `expire`, `incrby`, `incrbyfloat`, `hset`, `hincrby`, `hincrbyfloat`, `hdel`.
+
+## Connection Behavior
+
+- **Connection timeout**: 1 second
+- **Automatic reconnection**: Connections are tested with PING before use
+- **Multiple nodes**: Tries each node in order until one connects (no clustering support)

--- a/pkg/backends/secretsmanager/README.md
+++ b/pkg/backends/secretsmanager/README.md
@@ -1,0 +1,239 @@
+# Secrets Manager Backend
+
+The Secrets Manager backend enables confd to retrieve configuration data from [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/). It supports both plain string secrets and JSON secrets with automatic flattening.
+
+## Configuration
+
+The Secrets Manager backend uses the [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/) credential chain, which checks credentials in the following order:
+
+1. Environment variables
+2. Shared credentials file (`~/.aws/credentials`)
+3. IAM role for EC2/ECS/EKS
+
+### Environment Variables
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_REGION=us-east-1
+```
+
+### IAM Role for EC2/ECS/EKS
+
+When running on AWS compute (EC2, ECS, EKS), confd can use the instance/task role automatically. No credential configuration is needed.
+
+The region is automatically detected from EC2 instance metadata if `AWS_REGION` is not set.
+
+### Required IAM Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:*:*:secret:myapp/*"
+    }
+  ]
+}
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-flatten` | Disable JSON flattening, return raw secret string | `false` |
+| `--version-stage` | Version stage (AWSCURRENT, AWSPREVIOUS, or custom label) | `AWSCURRENT` |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` | AWS region (required) |
+| `AWS_PROFILE` | Named profile from credentials file |
+| `SECRETSMANAGER_LOCAL` | Enable local endpoint (for testing) |
+| `SECRETSMANAGER_ENDPOINT_URL` | Custom Secrets Manager endpoint URL |
+
+## Secret Types
+
+### Plain String Secrets
+
+```bash
+aws secretsmanager create-secret \
+  --name "/myapp/api-key" \
+  --secret-string "sk-1234567890abcdef"
+```
+
+Access as `/myapp/api-key`.
+
+### JSON Secrets (Automatic Flattening)
+
+JSON secrets are automatically flattened to individual key-value pairs:
+
+```bash
+aws secretsmanager create-secret \
+  --name "/myapp/database" \
+  --secret-string '{"url":"db.example.com","user":"admin","password":"secret123"}'
+```
+
+Access individual fields:
+- `/myapp/database/url` = `db.example.com`
+- `/myapp/database/user` = `admin`
+- `/myapp/database/password` = `secret123`
+
+### Binary Secrets
+
+Binary secrets are returned as base64-encoded strings.
+
+## Basic Example
+
+Create secrets in Secrets Manager:
+
+```bash
+# Plain string secret
+aws secretsmanager create-secret \
+  --name "/myapp/api-key" \
+  --secret-string "sk-1234567890"
+
+# JSON secret
+aws secretsmanager create-secret \
+  --name "/myapp/database" \
+  --secret-string '{"url":"db.example.com","user":"admin","password":"secret123"}'
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+  "/myapp/api-key",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+
+[api]
+key = {{getv "/myapp/api-key"}}
+```
+
+Run confd:
+
+```bash
+confd secretsmanager --onetime
+```
+
+## Advanced Example
+
+### Disable JSON Flattening
+
+To get the raw JSON string instead of flattened keys:
+
+```bash
+confd secretsmanager --no-flatten --onetime
+```
+
+Template with raw JSON:
+
+```
+{{$db := getv "/myapp/database" | json}}
+[database]
+url = {{$db.url}}
+user = {{$db.user}}
+```
+
+### Version Staging
+
+Retrieve a specific version of a secret:
+
+```bash
+# Get the previous version
+confd secretsmanager --version-stage AWSPREVIOUS --onetime
+
+# Get a custom-labeled version
+confd secretsmanager --version-stage MyCustomLabel --onetime
+```
+
+### Local Development with LocalStack
+
+```bash
+# Start LocalStack
+docker run -p 4566:4566 localstack/localstack
+
+# Create secret
+aws --endpoint-url=http://localhost:4566 secretsmanager create-secret \
+  --name "/myapp/config" \
+  --secret-string '{"key":"value"}'
+
+# Run confd
+export SECRETSMANAGER_LOCAL=true
+export SECRETSMANAGER_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+
+confd secretsmanager --onetime
+```
+
+### Kubernetes with IRSA
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: confd
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/confd-secrets-role
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  serviceAccountName: confd
+  containers:
+  - name: myapp
+    command:
+    - confd
+    - secretsmanager
+    - --interval=300
+```
+
+## Watch Mode Support
+
+Watch mode is **not supported** for the Secrets Manager backend. Use interval mode (`--interval`) for periodic polling.
+
+```bash
+confd secretsmanager --interval 300
+```
+
+## JSON Flattening Behavior
+
+When a JSON secret is retrieved:
+
+1. confd attempts to parse the secret string as JSON
+2. If successful and flattening is enabled, each top-level key becomes a nested path
+3. The original secret path is not available when flattening occurs
+4. Nested JSON objects are converted to string representation
+
+Example:
+
+```json
+{"host": "db.example.com", "port": 5432, "ssl": true}
+```
+
+Becomes:
+- `/myapp/database/host` = `db.example.com`
+- `/myapp/database/port` = `5432`
+- `/myapp/database/ssl` = `true`

--- a/pkg/backends/ssm/README.md
+++ b/pkg/backends/ssm/README.md
@@ -1,64 +1,197 @@
 # SSM Backend
 
-The SSM backend enables `confd` to pull configuration parameters from the AWS Systems Manager Parameter Store
+The SSM backend enables confd to retrieve configuration data from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html). It automatically decrypts SecureString parameters and supports recursive key retrieval.
 
 ## Configuration
 
-The SSM backend utilizes the AWS SDK which utilizes the same options required by
-the AWS CLI. The backend minimally requires setting the following:
+The SSM backend uses the [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/) credential chain, which checks credentials in the following order:
 
--   `AWS_ACCESS_KEY_ID`
--   `AWS_SECRET_ACCESS_KEY`
--   `AWS_DEFAULT_REGION` and/or `AWS_REGION`
+1. Environment variables
+2. Shared credentials file (`~/.aws/credentials`)
+3. IAM role for EC2/ECS/EKS
 
 ### Environment Variables
 
-Environment variables can be used to provide the required configurations to
-`confd`. They will override configurations set in the config and credentials
-files.
-
-```
+```bash
 export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-export AWS_DEFAULT_REGION=us-east-2
+export AWS_REGION=us-east-1
 ```
 
 ### Config and Credentials Files
 
-AWS credentials and configuration can be stored in the standard AWS CLI config
-files. These may be set up manually or via `aws configure`
+AWS credentials can be stored in the standard AWS CLI configuration files.
 
-\~/.aws/credentials
+`~/.aws/credentials`:
 
-```
+```ini
 [default]
-aws_access_key_id=AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
-\~/.aws/config
+`~/.aws/config`:
 
-```
+```ini
 [default]
-region=us-east-2
+region = us-east-1
 ```
 
-### IAM Role for EC2
+Use a named profile with `AWS_PROFILE`:
 
-An IAM role can be used to grant `confd` permissions to SSM. When used you will
-not need to set `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY`. When `confd` is
-executed on an EC2 instance it will acquire the AWS Region setting from EC2
-Metadata.
+```bash
+export AWS_PROFILE=production
+confd ssm --onetime
+```
 
-Setup of IAM roles for EC2 instances is well documented in the AWS User Guides.
+### IAM Role for EC2/ECS/EKS
 
+When running on AWS compute (EC2, ECS, EKS), confd can use the instance/task role automatically. No credential configuration is needed.
+
+For EKS with IAM Roles for Service Accounts (IRSA):
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: confd
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/confd-ssm-role
+```
+
+The region is automatically detected from EC2 instance metadata if `AWS_REGION` is not set.
+
+### Required IAM Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParametersByPath"
+      ],
+      "Resource": "arn:aws:ssm:*:*:parameter/myapp/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "arn:aws:kms:*:*:key/*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "ssm.*.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+```
 
 ## Options
 
+The SSM backend has no backend-specific flags. It uses standard AWS environment variables for configuration:
 
+| Environment Variable | Description |
+|---------------------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` | AWS region |
+| `AWS_PROFILE` | Named profile from credentials file |
+| `SSM_LOCAL` | Enable local endpoint (for testing) |
+| `SSM_ENDPOINT_URL` | Custom SSM endpoint URL |
 
 ## Basic Example
 
+Create parameters in SSM:
 
+```bash
+aws ssm put-parameter --name "/myapp/database/url" --type "String" --value "db.example.com"
+aws ssm put-parameter --name "/myapp/database/user" --type "String" --value "admin"
+aws ssm put-parameter --name "/myapp/database/password" --type "SecureString" --value "secret123"
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd ssm --onetime
+```
 
 ## Advanced Example
+
+Using hierarchical parameters with multiple applications:
+
+```bash
+# Create parameters for multiple apps
+aws ssm put-parameter --name "/production/app1/db_host" --type "String" --value "db1.example.com"
+aws ssm put-parameter --name "/production/app1/db_pass" --type "SecureString" --value "secret1"
+aws ssm put-parameter --name "/production/app2/api_key" --type "SecureString" --value "key123"
+```
+
+Template resource with prefix (`/etc/confd/conf.d/app1.toml`):
+
+```toml
+[template]
+prefix = "/production/app1"
+src = "app1.conf.tmpl"
+dest = "/etc/app1/config.conf"
+keys = [
+  "/db_host",
+  "/db_pass",
+]
+```
+
+Running as a daemon with interval polling:
+
+```bash
+confd ssm --interval 300
+```
+
+### Local Development with LocalStack
+
+For local testing with LocalStack:
+
+```bash
+export SSM_LOCAL=true
+export SSM_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+
+confd ssm --onetime
+```
+
+## Watch Mode Support
+
+Watch mode is **not supported** for the SSM backend. Use interval mode (`--interval`) for periodic polling.
+
+## Parameter Types
+
+SSM Parameter Store supports three parameter types:
+
+- **String** - Plain text values
+- **StringList** - Comma-separated values (returned as-is)
+- **SecureString** - Encrypted with KMS (automatically decrypted by confd)
+
+All parameter types are retrieved and decrypted automatically.

--- a/pkg/backends/vault/kubernetes-auth.md
+++ b/pkg/backends/vault/kubernetes-auth.md
@@ -97,7 +97,7 @@ These are steps to get vault with Kubernetes auth working on minikube.
   # And template
   echo '{{getv "/secret/foo"}}' > /etc/confd/templates/test.conf.tmpl
   # and finally run confd
-  confd -onetime -backend vault -auth-type kubernetes -role confd -node http://vault-vault:8200 -log-level debug
+  confd vault --node http://vault-vault:8200 --auth-type kubernetes --role-id confd --log-level debug --onetime
   ```
 
 - Check `/tmp/test.conf`, it should contain your secret

--- a/pkg/backends/zookeeper/README.md
+++ b/pkg/backends/zookeeper/README.md
@@ -1,0 +1,185 @@
+# Zookeeper Backend
+
+The Zookeeper backend enables confd to retrieve configuration data from [Apache ZooKeeper](https://zookeeper.apache.org/), a distributed coordination service.
+
+## Configuration
+
+### Basic Connection
+
+Connect to ZooKeeper:
+
+```bash
+confd zookeeper --node 127.0.0.1:2181 --onetime
+```
+
+Multiple nodes for high availability:
+
+```bash
+confd zookeeper \
+  --node zk1.example.com:2181 \
+  --node zk2.example.com:2181 \
+  --node zk3.example.com:2181 --onetime
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-n, --node` | ZooKeeper server address (can be specified multiple times) | - |
+
+Note: ZooKeeper authentication (SASL/Kerberos) is not currently supported by this backend.
+
+## Basic Example
+
+Create znodes in ZooKeeper:
+
+```bash
+# Using zkCli.sh
+zkCli.sh create /myapp ""
+zkCli.sh create /myapp/database ""
+zkCli.sh create /myapp/database/url "db.example.com"
+zkCli.sh create /myapp/database/user "admin"
+zkCli.sh create /myapp/database/password "secret123"
+```
+
+Or using the ZooKeeper shell:
+
+```
+[zk: localhost:2181(CONNECTED) 0] create /myapp ""
+[zk: localhost:2181(CONNECTED) 1] create /myapp/database ""
+[zk: localhost:2181(CONNECTED) 2] create /myapp/database/url "db.example.com"
+[zk: localhost:2181(CONNECTED) 3] create /myapp/database/user "admin"
+[zk: localhost:2181(CONNECTED) 4] create /myapp/database/password "secret123"
+```
+
+Create template resource (`/etc/confd/conf.d/myapp.toml`):
+
+```toml
+[template]
+src = "myapp.conf.tmpl"
+dest = "/etc/myapp/config.conf"
+keys = [
+  "/myapp/database",
+]
+```
+
+Create template (`/etc/confd/templates/myapp.conf.tmpl`):
+
+```
+[database]
+url = {{getv "/myapp/database/url"}}
+user = {{getv "/myapp/database/user"}}
+password = {{getv "/myapp/database/password"}}
+```
+
+Run confd:
+
+```bash
+confd zookeeper --node 127.0.0.1:2181 --onetime
+```
+
+## Advanced Example
+
+### Service Discovery Pattern
+
+Store service endpoints in ZooKeeper:
+
+```bash
+zkCli.sh create /services ""
+zkCli.sh create /services/api ""
+zkCli.sh create /services/api/node1 "10.0.1.100:8080"
+zkCli.sh create /services/api/node2 "10.0.1.101:8080"
+zkCli.sh create /services/api/node3 "10.0.1.102:8080"
+```
+
+Template for load balancer config:
+
+```
+upstream api {
+{{range gets "/services/api/*"}}
+    server {{.Value}};
+{{end}}
+}
+```
+
+### Hierarchical Configuration
+
+```bash
+# Environment-specific config
+zkCli.sh create /config ""
+zkCli.sh create /config/production ""
+zkCli.sh create /config/production/database ""
+zkCli.sh create /config/production/database/host "prod-db.example.com"
+zkCli.sh create /config/production/database/port "5432"
+```
+
+Template resource with prefix:
+
+```toml
+[template]
+prefix = "/config/production"
+src = "app.conf.tmpl"
+dest = "/etc/app/config.conf"
+keys = [
+  "/database",
+]
+```
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+  - name: myapp
+    command:
+    - confd
+    - zookeeper
+    - --node=zk-0.zk-headless.default.svc:2181
+    - --node=zk-1.zk-headless.default.svc:2181
+    - --node=zk-2.zk-headless.default.svc:2181
+    - --watch
+```
+
+## Watch Mode Support
+
+Watch mode **is supported** for the ZooKeeper backend. confd uses ZooKeeper's native watch mechanism for real-time updates.
+
+```bash
+confd zookeeper --node 127.0.0.1:2181 --watch
+```
+
+confd watches:
+- **Data changes**: `NodeDataChanged` events on leaf nodes
+- **Child changes**: `NodeChildrenChanged` events on parent nodes
+
+When any watched znode changes, confd re-renders affected templates.
+
+## ZooKeeper Data Model
+
+ZooKeeper uses a hierarchical namespace similar to a filesystem:
+
+```
+/
+├── myapp
+│   ├── database
+│   │   ├── url = "db.example.com"
+│   │   ├── user = "admin"
+│   │   └── password = "secret"
+│   └── cache
+│       ├── host = "redis.example.com"
+│       └── port = "6379"
+```
+
+- **Znodes** can have both data and children
+- **Leaf znodes** (no children) store the actual configuration values
+- **Parent znodes** are traversed recursively to find all values
+
+## Connection Behavior
+
+- **Session timeout**: 1 second
+- **Automatic reconnection**: ZooKeeper client handles reconnection automatically
+- **Ensemble support**: Specify multiple nodes for automatic failover


### PR DESCRIPTION
## Summary

- Update all CLI examples to use new subcommand syntax (e.g., `confd etcd` instead of `confd -backend etcd`)
- Update single-dash flags to double-dash (e.g., `--onetime` instead of `-onetime`)
- Create comprehensive README for each backend in `pkg/backends/<backend>/`
- Rewrite `command-line-flags.md` to document the new subcommand-based CLI
- Move `vault-kubernetes-auth.md` to `pkg/backends/vault/kubernetes-auth.md`
- Simplify `quick-start-guide.md` with backend comparison table and links
- Fix `vault/README.md` which previously contained SSM content
- Update `configuration-guide.md` backend references

### New Backend READMEs

Each backend now has a comprehensive README covering:
- Authentication methods and configuration
- Environment variables  
- Backend-specific options
- Basic and advanced examples
- Watch mode support documentation
- Kubernetes deployment examples

### Files Changed

**New files (9):**
- `pkg/backends/acm/README.md`
- `pkg/backends/consul/README.md`
- `pkg/backends/dynamodb/README.md`
- `pkg/backends/env/README.md`
- `pkg/backends/etcd/README.md`
- `pkg/backends/file/README.md`
- `pkg/backends/redis/README.md`
- `pkg/backends/secretsmanager/README.md`
- `pkg/backends/zookeeper/README.md`

**Updated files (9):**
- `docs/command-line-flags.md` - Complete rewrite for new CLI
- `docs/configuration-guide.md`
- `docs/dns-srv-records.md`
- `docs/installation.md`
- `docs/logging.md`
- `docs/noop-mode.md`
- `docs/quick-start-guide.md`
- `docs/tomcat-sample.md`
- `pkg/backends/ssm/README.md`
- `pkg/backends/vault/README.md`

**Moved files (1):**
- `docs/vault-kubernetes-auth.md` → `pkg/backends/vault/kubernetes-auth.md`

## Test plan

- [x] Verify all CLI examples use new subcommand syntax
- [x] Verify no old `-backend` flag references remain
- [x] Verify all backend READMEs follow consistent structure

Closes #347