### PR TITLE
test: Improve code coverage from 56% to 60.5%

### DIFF
--- a/pkg/backends/acm/client_test.go
+++ b/pkg/backends/acm/client_test.go
@@ -478,3 +478,39 @@ func TestGetValues_ExportPrivateKey_MultipleCertificates(t *testing.T) {
 		t.Errorf("GetValues() = %v, want %v", result, expected)
 	}
 }
+
+func TestHealthCheck_Success(t *testing.T) {
+	mock := &mockACM{
+		listCertificatesFunc: func(ctx context.Context, input *acm.ListCertificatesInput, opts ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
+			return &acm.ListCertificatesOutput{
+				CertificateSummaryList: []types.CertificateSummary{},
+			}, nil
+		},
+	}
+
+	client := newTestClient(mock)
+
+	err := client.HealthCheck(context.Background())
+	if err != nil {
+		t.Errorf("HealthCheck() unexpected error: %v", err)
+	}
+}
+
+func TestHealthCheck_Error(t *testing.T) {
+	expectedErr := errors.New("access denied")
+	mock := &mockACM{
+		listCertificatesFunc: func(ctx context.Context, input *acm.ListCertificatesInput, opts ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
+			return nil, expectedErr
+		},
+	}
+
+	client := newTestClient(mock)
+
+	err := client.HealthCheck(context.Background())
+	if err == nil {
+		t.Error("HealthCheck() expected error, got nil")
+	}
+	if err != expectedErr {
+		t.Errorf("HealthCheck() error = %v, want %v", err, expectedErr)
+	}
+}

--- a/pkg/backends/env/client_test.go
+++ b/pkg/backends/env/client_test.go
@@ -197,3 +197,16 @@ func TestWatchPrefix(t *testing.T) {
 		t.Errorf("WatchPrefix() index = %d, want 0", index)
 	}
 }
+
+func TestHealthCheck(t *testing.T) {
+	client, err := NewEnvClient()
+	if err != nil {
+		t.Fatalf("NewEnvClient() error: %v", err)
+	}
+
+	// HealthCheck for env backend should always return nil
+	err = client.HealthCheck(context.Background())
+	if err != nil {
+		t.Errorf("HealthCheck() unexpected error: %v", err)
+	}
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,148 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestSetTag(t *testing.T) {
+	originalTag := tag
+	defer func() { tag = originalTag }()
+
+	SetTag("test-app")
+	if tag != "test-app" {
+		t.Errorf("SetTag() tag = %q, want %q", tag, "test-app")
+	}
+}
+
+func TestSetLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    string
+		expected logrus.Level
+	}{
+		{"debug level", "debug", logrus.DebugLevel},
+		{"info level", "info", logrus.InfoLevel},
+		{"warn level", "warn", logrus.WarnLevel},
+		{"warning level", "warning", logrus.WarnLevel},
+		{"error level", "error", logrus.ErrorLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetLevel(tt.level)
+			if logrus.GetLevel() != tt.expected {
+				t.Errorf("SetLevel(%q) level = %v, want %v", tt.level, logrus.GetLevel(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestSetFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		format         string
+		expectedFormat string
+	}{
+		{"json format", "json", "*logrus.JSONFormatter"},
+		{"text format", "text", "*log.ConfdFormatter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetFormat(tt.format)
+			formatter := logrus.StandardLogger().Formatter
+			typeName := strings.Replace(
+				strings.Replace(fmt.Sprintf("%T", formatter), "github.com/sirupsen/logrus", "logrus", 1),
+				"github.com/abtreece/confd/pkg/log", "log", 1,
+			)
+			if typeName != tt.expectedFormat {
+				t.Errorf("SetFormat(%q) formatter type = %v, want %v", tt.format, typeName, tt.expectedFormat)
+			}
+		})
+	}
+}
+
+func TestConfdFormatter(t *testing.T) {
+	formatter := &ConfdFormatter{}
+	entry := &logrus.Entry{
+		Level:   logrus.InfoLevel,
+		Message: "test message",
+	}
+
+	output, err := formatter.Format(entry)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "INFO") {
+		t.Errorf("Format() output should contain 'INFO', got %q", outputStr)
+	}
+	if !strings.Contains(outputStr, "test message") {
+		t.Errorf("Format() output should contain 'test message', got %q", outputStr)
+	}
+	if !strings.HasSuffix(outputStr, "\n") {
+		t.Errorf("Format() output should end with newline, got %q", outputStr)
+	}
+}
+
+func TestDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.DebugLevel)
+	defer logrus.SetOutput(nil)
+
+	Debug("test %s", "debug")
+
+	output := buf.String()
+	if !strings.Contains(output, "test debug") {
+		t.Errorf("Debug() output = %q, want to contain 'test debug'", output)
+	}
+}
+
+func TestError(t *testing.T) {
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.ErrorLevel)
+	defer logrus.SetOutput(nil)
+
+	Error("test %s", "error")
+
+	output := buf.String()
+	if !strings.Contains(output, "test error") {
+		t.Errorf("Error() output = %q, want to contain 'test error'", output)
+	}
+}
+
+func TestInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.InfoLevel)
+	defer logrus.SetOutput(nil)
+
+	Info("test %s", "info")
+
+	output := buf.String()
+	if !strings.Contains(output, "test info") {
+		t.Errorf("Info() output = %q, want to contain 'test info'", output)
+	}
+}
+
+func TestWarning(t *testing.T) {
+	var buf bytes.Buffer
+	logrus.SetOutput(&buf)
+	logrus.SetLevel(logrus.WarnLevel)
+	defer logrus.SetOutput(nil)
+
+	Warning("test %s", "warning")
+
+	output := buf.String()
+	if !strings.Contains(output, "test warning") {
+		t.Errorf("Warning() output = %q, want to contain 'test warning'", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for previously uncovered code paths
- Improve overall test coverage from 56% to 60.5%

## Changes

### New Tests Added

**pkg/log (0% → 84.2%)**
- Tests for SetTag, SetLevel, SetFormat, ConfdFormatter
- Tests for Debug, Error, Info, Warning log functions

**Backend HealthCheck Tests**
- `env`: TestHealthCheck (100% coverage)
- `consul`: TestHealthCheck_Success, TestHealthCheck_Error
- `file`: 4 tests covering success, missing file, multiple files, partial missing
- `dynamodb`: TestHealthCheck_Success, TestHealthCheck_Error
- `ssm`: TestHealthCheck_Success, TestHealthCheck_Error
- `acm`: TestHealthCheck_Success, TestHealthCheck_Error
- `secretsmanager`: 3 tests for not found, exists, error cases
- `zookeeper`: TestHealthCheck_Success, TestHealthCheck_Error
- `redis`: TestHealthCheck_Success, TestHealthCheck_PingFails

**pkg/template/template_funcs (56.8% → 64.5%)**
- GetHostname, LookupIfaceIPV4/6 tests
- LookupSRV and sortSRV tests

**pkg/template/resource**
- runCommand tests (4 tests: success, failure, invalid command, output)
- check tests (3 tests: success, failure, invalid template)
- reload tests (5 tests including rate limiting and template variables)

## Coverage by Package

| Package | Before | After |
|---------|--------|-------|
| pkg/log | 0% | 84.2% |
| pkg/backends/env | 95.2% | 100% |
| pkg/backends/redis | 50.3% | 53.1% |
| pkg/template | 56.8% | 64.5% |
| pkg/backends/file | 79.3% | 83.7% |
| pkg/backends/zookeeper | 77.8% | 80.2% |
| **Total** | **56%** | **60.5%** |

## Test plan

- [x] All existing tests pass
- [x] New tests pass
- [x] Coverage verified with `go test ./... -cover`

🤖 Generated with [Claude Code](https://claude.com/claude-code)