### PR TITLE
ci: Prevent duplicate integration test runs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,7 +1,11 @@
 name: Integration Tests
-on: 
+on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * 0' # weekly
 


### PR DESCRIPTION
## Summary
Update integration test workflow to use branch-specific triggers to eliminate duplicate test runs.

## Changes
- Run on `push` only to `main` branch
- Run on `pull_request` only targeting `main` branch  
- Continue weekly scheduled runs (unchanged)

## Problem
Previously, the workflow triggered on both `push` and `pull_request` events without branch filters. This caused duplicate runs when pushing to PR branches:
1. `push` event fires when committing to PR branch
2. `pull_request` + `synchronize` event fires for the same commit

## Solution
With branch-specific triggers:
- **PRs**: Run once per commit via `pull_request` + `synchronize` event
- **Main branch**: Run on direct pushes (merges, direct commits)
- **Weekly**: Still runs as scheduled safety check

The `pull_request` trigger automatically includes `opened`, `synchronize`, and `reopened` events, so integration tests still run on every PR commit.

## Benefits
- Eliminates duplicate workflow runs
- Reduces CI resource usage
- Maintains full test coverage
- Follows pattern already used in `codecov.yml`

## Testing
This PR itself will demonstrate the fix - it should only trigger integration tests once via the `pull_request` event, not twice.