### PR TITLE
ci: Fix gosec code scanning by uploading SARIF results

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -25,4 +25,9 @@ jobs:
         uses: securego/gosec@master
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
-          args: '-no-fail -fmt=json -out=gosec-report.json ./...'
+          args: '-no-fail -fmt sarif -out results.sarif ./...'
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Fix the "Code scanning configuration error" in gosec security checks by properly uploading SARIF results to GitHub Code Scanning.

## Problem
The gosec workflow was generating JSON reports but never uploading them to GitHub's Security tab, causing configuration errors:
> Code scanning configuration error
> Golang security checks by gosec is reporting errors. Check the status page for help.

## Root Cause
The workflow was configured to:
1. Generate JSON output: `-fmt=json -out=gosec-report.json`
2. But never upload the results to GitHub

GitHub Code Scanning requires SARIF format and an explicit upload step to display results in the Security tab.

## Changes
- **Output format**: Changed from JSON to SARIF (`-fmt sarif -out results.sarif`)
- **Added upload step**: Use `github/codeql-action/upload-sarif@v3` to send results to GitHub
- **Updated action version**: Use v3 of upload-sarif action

## Result
After this change, gosec security findings will properly appear in the GitHub Security tab under Code Scanning, alongside CodeQL results.

## References
- [GitHub Docs: Uploading a SARIF file](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github)
- [securego/gosec GitHub Action](https://github.com/marketplace/actions/gosec-security-checker)