### PR TITLE
fix(redis): Add automatic reconnection for PubSub watch mode

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,3 +52,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/pkg/backends/redis/client.go
+++ b/pkg/backends/redis/client.go
@@ -385,7 +385,7 @@ func (c *Client) watchWithReconnect(ctx context.Context, prefix string) {
 		// Apply backoff delay for reconnection attempts
 		if attempt > 0 {
 			backoff := calculateBackoff(attempt-1, c.retryConfig)
-			log.Info("Redis PubSub reconnection attempt %d/%d after %v", attempt, c.retryConfig.MaxRetries, backoff)
+			log.Info("Redis PubSub reconnection attempt %d/%d after %v", attempt, c.retryConfig.MaxRetries+1, backoff)
 			time.Sleep(backoff)
 		}
 
@@ -397,7 +397,7 @@ func (c *Client) watchWithReconnect(ctx context.Context, prefix string) {
 			if attempt > c.retryConfig.MaxRetries {
 				log.Error("Redis PubSub connection failed after %d attempts: %v", attempt, err)
 				select {
-				case c.pscChan <- watchResponse{0, fmt.Errorf("pubsub connection failed after %d attempts: %w", attempt, err)}:
+				case c.pscChan <- watchResponse{0, fmt.Errorf("PubSub connection failed after %d attempts: %w", attempt, err)}:
 				case <-ctx.Done():
 				}
 				return


### PR DESCRIPTION
## Summary
Implement robust automatic reconnection for Redis PubSub connections to prevent watch mode from stopping permanently when connections are lost.

Fixes #392

## Problem
The Redis `WatchPrefix` creates a PubSub connection but lacks reconnection logic. When the connection is lost:
- The goroutine exits permanently
- Watch mode stops working
- Manual restart required to resume watching
- Production reliability issue

**Before (lines 367-373):**
```go
case msg, ok := <-ch:
    if !ok {
        // Channel closed - subscription ended
        c.pscChan <- watchResponse{0, nil}
        return  // Goroutine exits, watch stops permanently
    }
```

## Solution
Extract PubSub logic into a new `watchWithReconnect()` method that:
1. **Reconnects automatically** when channel closes
2. **Uses exponential backoff** with existing `retryConfig` (100ms-5s, 30% jitter)
3. **Maintains subscription** pattern across reconnections
4. **Logs connection state** for visibility
5. **Respects max retries** before giving up (default: 3 attempts)
6. **Handles cleanup** properly on context cancellation

## Changes

### New Method: `watchWithReconnect()`
- Manages PubSub lifecycle with reconnection loop
- Applies exponential backoff between attempts (reuses infrastructure from PR #405)
- Cleans up resources (pubsub, rClient) properly
- Logs connection events:
  - **Info**: Reconnection attempts, success after retries
  - **Warning**: Connection failures, channel closures
  - **Debug**: Subscription patterns, message processing

### Simplified `WatchPrefix()`
- Delegates to `watchWithReconnect()` for connection management
- Keeps existing external API unchanged
- Maintains backward compatibility

## Behavior

### On Connection Loss:
1. Log warning: "Redis PubSub channel closed, attempting reconnection"
2. Clean up current connection
3. Apply exponential backoff delay
4. Attempt reconnection with createClient()
5. Resubscribe to same keyspace pattern
6. Resume watching

### On Reconnection Failure:
- Retry up to `MaxRetries` (default: 3)
- After exhausting retries, send error to pscChan
- Log error: "Redis PubSub connection failed after N attempts"

### On Context Cancellation:
- Exit reconnection loop immediately
- Clean up resources (pubsub, rClient)
- No error sent to pscChan

## Testing
- All existing unit tests pass
- Integration tests will verify reconnection behavior with real Redis
- Manual testing recommended for network disruption scenarios

## Expected Benefits
- ✅ More resilient watch mode
- ✅ Better production reliability
- ✅ Reduced operational burden (no manual restarts)
- ✅ Better observability through logging
- ✅ Reuses existing retry infrastructure

## Example Logs

**Initial connection:**
```
DEBUG Redis PubSub subscribed to pattern: __keyspace@0__:/app/*
```

**Connection lost:**
```
WARNING Redis PubSub channel closed, attempting reconnection
INFO Redis PubSub reconnection attempt 1/3 after 100ms
```

**Reconnection successful:**
```
INFO Redis PubSub reconnected successfully after 1 attempts
DEBUG Redis PubSub subscribed to pattern: __keyspace@0__:/app/*
```

**Exhausted retries:**
```
ERROR Redis PubSub connection failed after 4 attempts: failed to connect to any redis node after retries: ...
```