### PR TITLE
test(vault): Increase test coverage from 31.5% to 62.1%

### DIFF
--- a/pkg/backends/vault/client.go
+++ b/pkg/backends/vault/client.go
@@ -237,9 +237,9 @@ func (c *Client) GetValues(ctx context.Context, paths []string) (map[string]stri
 			log.Error("empty response getting mount info for %s", mount)
 			continue
 		}
-		defer resp.Body.Close()
 
 		secret, err := vaultapi.ParseSecret(resp.Body)
+		resp.Body.Close() // Close immediately after parsing to avoid resource leak in loop
 		if err != nil {
 			log.Error("failed to parse secret for %s: %v", mount, err)
 			continue


### PR DESCRIPTION
## Summary
- Increases Vault backend test coverage from 31.5% to 62.1%, exceeding the 60% target set in #397
- Adds comprehensive unit tests for `getKVVersion`, `GetValues`, `HealthCheck`, and `recursiveListSecretWithLogical`
- Uses mock interfaces to test Vault client behavior without requiring a running Vault instance

## Test plan
- [x] Run `go test ./pkg/backends/vault/...` - all tests pass
- [x] Verify coverage with `go test -cover` shows 62.1%
- [x] Run full test suite with `go test ./...` - all tests pass

Fixes #397