### PR TITLE
chore: Update Go version to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine
+FROM golang:1.25-alpine
 
 RUN apk add --no-cache make git
 RUN mkdir -p /go/src/github.com/abtreece/confd && \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Building
 
-Go 1.24+ is required to build confd.
+Go 1.25+ is required to build confd.
 
 ```
 $ git clone https://github.com/abtreece/confd.git


### PR DESCRIPTION
Update Go version to 1.25 across all build configuration and documentation.

- Dockerfile: Updated golang:1.22.2-alpine to golang:1.25-alpine
- README.md: Updated minimum required Go version to 1.25+

This ensures consistency across docker builds, CI/CD pipelines, and documentation.