### PR TITLE
perf: pre-allocate template slice in getTemplateResources

### DIFF
--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -495,7 +495,6 @@ func (p *batchWatchProcessor) processBatch() {
 
 func getTemplateResources(config Config) ([]*TemplateResource, error) {
 	var lastError error
-	templates := make([]*TemplateResource, 0)
 	log.Debug("Loading template resources from confdir %s", config.ConfDir)
 	if !util.IsFileExist(config.ConfDir) {
 		log.Warning("Cannot load template resources: confdir '%s' does not exist", config.ConfDir)
@@ -509,6 +508,9 @@ func getTemplateResources(config Config) ([]*TemplateResource, error) {
 	if len(paths) < 1 {
 		log.Warning("Found no templates")
 	}
+
+	// Pre-allocate slice capacity based on discovered template files
+	templates := make([]*TemplateResource, 0, len(paths))
 
 	for _, p := range paths {
 		log.Debug("Found template: %s", p)


### PR DESCRIPTION
## Summary

- Pre-allocate template slice capacity in `getTemplateResources()` using the count from `RecursiveFilesLookup`
- Eliminates repeated slice growth allocations during template loading

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

Fixes #441