### PR TITLE
perf: cache prefixed keys on TemplateResource initialization

### DIFF
--- a/pkg/template/backend_fetcher_test.go
+++ b/pkg/template/backend_fetcher_test.go
@@ -83,13 +83,14 @@ func TestFetchValues_Success(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/app",
-		Ctx:         context.Background(),
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/app",
+		PrefixedKeys: []string{"/app/database/host", "/app/database/port", "/app/api/key"},
+		Ctx:          context.Background(),
 	})
 
-	err := fetcher.fetchValues([]string{"database/host", "database/port", "api/key"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}
@@ -116,12 +117,13 @@ func TestFetchValues_BackendError(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/app",
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/app",
+		PrefixedKeys: []string{"/app/key1", "/app/key2"},
 	})
 
-	err := fetcher.fetchValues([]string{"key1", "key2"})
+	err := fetcher.fetchValues()
 	if err == nil {
 		t.Error("fetchValues() expected error, got nil")
 	}
@@ -146,12 +148,13 @@ func TestFetchValues_PurgesExistingData(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/app",
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/app",
+		PrefixedKeys: []string{"/app/new/key"},
 	})
 
-	err := fetcher.fetchValues([]string{"new/key"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}
@@ -183,12 +186,13 @@ func TestFetchValues_NormalizesKeys(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/production/app",
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/production/app",
+		PrefixedKeys: []string{"/production/app/database/host", "/production/app/database/port"},
 	})
 
-	err := fetcher.fetchValues([]string{"database/host", "database/port"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}
@@ -216,11 +220,12 @@ func TestFetchValues_WithTimeout(t *testing.T) {
 		StoreClient:    client,
 		Store:          store,
 		Prefix:         "/app",
+		PrefixedKeys:   []string{"/app/key"},
 		Ctx:            context.Background(),
 		BackendTimeout: 5 * time.Second,
 	})
 
-	err := fetcher.fetchValues([]string{"key"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}
@@ -251,11 +256,12 @@ func TestFetchValues_WithoutTimeout(t *testing.T) {
 		StoreClient:    client,
 		Store:          store,
 		Prefix:         "/app",
+		PrefixedKeys:   []string{"/app/key"},
 		Ctx:            context.Background(),
 		BackendTimeout: 0, // No timeout
 	})
 
-	err := fetcher.fetchValues([]string{"key"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}
@@ -280,13 +286,14 @@ func TestFetchValues_NilContext(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/app",
-		Ctx:         nil, // No context provided
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/app",
+		PrefixedKeys: []string{"/app/key"},
+		Ctx:          nil, // No context provided
 	})
 
-	err := fetcher.fetchValues([]string{"key"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}
@@ -326,12 +333,13 @@ func TestFetchValues_EmptyKeys(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/app",
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/app",
+		PrefixedKeys: []string{},
 	})
 
-	err := fetcher.fetchValues([]string{})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() with empty keys should not error: %v", err)
 	}
@@ -350,12 +358,13 @@ func TestFetchValues_EmptyResult(t *testing.T) {
 	}
 
 	fetcher := newBackendFetcher(backendFetcherConfig{
-		StoreClient: client,
-		Store:       store,
-		Prefix:      "/app",
+		StoreClient:  client,
+		Store:        store,
+		Prefix:       "/app",
+		PrefixedKeys: []string{"/app/key"},
 	})
 
-	err := fetcher.fetchValues([]string{"key"})
+	err := fetcher.fetchValues()
 	if err != nil {
 		t.Errorf("fetchValues() unexpected error: %v", err)
 	}

--- a/pkg/template/preflight.go
+++ b/pkg/template/preflight.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/abtreece/confd/pkg/log"
-	"github.com/abtreece/confd/pkg/util"
 )
 
 // Preflight performs connectivity and configuration checks without processing templates.
@@ -47,8 +46,7 @@ func Preflight(config Config) error {
 	var errors []string
 
 	for _, t := range ts {
-		keys := util.AppendPrefix(t.Prefix, t.Keys)
-		vals, err := config.StoreClient.GetValues(ctx, keys)
+		vals, err := config.StoreClient.GetValues(ctx, t.prefixedKeys)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("%s: backend error: %v", t.Src, err))
 			continue

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -146,8 +146,7 @@ func (p *watchProcessor) Process() {
 		if metrics.Enabled() {
 			totalKeys := 0
 			for _, t := range ts {
-				keys := util.AppendPrefix(t.Prefix, t.Keys)
-				totalKeys += len(keys)
+				totalKeys += len(t.prefixedKeys)
 			}
 			metrics.WatchedKeys.Set(float64(totalKeys))
 		}
@@ -203,7 +202,7 @@ func (p *watchProcessor) Process() {
 
 func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
 	defer p.wg.Done()
-	keys := util.AppendPrefix(t.Prefix, t.Keys)
+	keys := t.prefixedKeys
 
 	ctx := p.config.Ctx
 	if ctx == nil {
@@ -318,8 +317,7 @@ func (p *batchWatchProcessor) Process() {
 		if metrics.Enabled() {
 			totalKeys := 0
 			for _, t := range ts {
-				keys := util.AppendPrefix(t.Prefix, t.Keys)
-				totalKeys += len(keys)
+				totalKeys += len(t.prefixedKeys)
 			}
 			metrics.WatchedKeys.Set(float64(totalKeys))
 		}
@@ -380,7 +378,7 @@ func (p *batchWatchProcessor) Process() {
 
 func (p *batchWatchProcessor) monitorForBatch(t *TemplateResource) {
 	defer p.wg.Done()
-	keys := util.AppendPrefix(t.Prefix, t.Keys)
+	keys := t.prefixedKeys
 
 	ctx := p.config.Ctx
 	if ctx == nil {


### PR DESCRIPTION
## Summary

- Cache the result of `util.AppendPrefix()` on `TemplateResource` initialization to avoid repeated computation on every `process()` cycle
- Add `prefixedKeys` field to `TemplateResource` struct computed once during initialization
- Update `backendFetcher` to store and use pre-computed prefixed keys
- Change `fetchValues()` signature to use stored keys instead of parameter

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Build succeeds (`make build`)
- [ ] Integration tests (requires backend services)

Fixes #445

🤖 Generated with [Claude Code](https://claude.ai/code)