### PR TITLE
perf: pool map allocations in memkv List/ListDir operations

### DIFF
--- a/pkg/memkv/store.go
+++ b/pkg/memkv/store.go
@@ -9,6 +9,12 @@ import (
 	"sync"
 )
 
+// seenPoolCapacity is the initial capacity for maps in seenPool.
+// Sized for typical List/ListDir usage where templates iterate over
+// hierarchical key structures. A capacity of 64 balances avoiding
+// reallocations for common workloads against over-allocating memory.
+const seenPoolCapacity = 64
+
 var (
 	// ErrNotExist is returned when a key does not exist in the store.
 	ErrNotExist = errors.New("key does not exist")
@@ -19,7 +25,7 @@ var (
 	// This reduces allocations during high-frequency template processing.
 	seenPool = sync.Pool{
 		New: func() interface{} {
-			return make(map[string]struct{}, 64)
+			return make(map[string]struct{}, seenPoolCapacity)
 		},
 	}
 )

--- a/pkg/memkv/store_test.go
+++ b/pkg/memkv/store_test.go
@@ -311,13 +311,16 @@ func TestKVPairs_Sort(t *testing.T) {
 }
 
 // setupBenchmarkStore creates a store with a hierarchical key structure for benchmarking.
+// Creates exactly numKeys keys in the structure: /app/service{i}/config/key{j}
 func setupBenchmarkStore(numKeys int) *Store {
 	s := New()
+	created := 0
 	// Create a hierarchical structure: /app/service{i}/config/key{j}
-	for i := 0; i < numKeys/10; i++ {
-		for j := 0; j < 10; j++ {
+	for i := 0; created < numKeys; i++ {
+		for j := 0; j < 10 && created < numKeys; j++ {
 			key := fmt.Sprintf("/app/service%d/config/key%d", i, j)
 			s.Set(key, fmt.Sprintf("value%d", j))
+			created++
 		}
 	}
 	return s


### PR DESCRIPTION
## Summary

- Use `sync.Pool` to reuse the `seen` map in `List()` and `ListDir()` operations
- Reduces allocations during high-frequency template processing (watch mode, short intervals)
- Add benchmarks for List/ListDir operations

## Changes

- Add `seenPool` with initial capacity of 64 entries
- Modify `List()` and `ListDir()` to get/put maps from pool
- Use `clear()` builtin (Go 1.21+) to reset maps before returning to pool
- Add 6 benchmarks covering basic, high-frequency, and large store scenarios

## Benchmark Results

```
BenchmarkList-8                      96932    11395 ns/op    6594 B/op    102 allocs/op
BenchmarkList_HighFrequency-8        37704    31726 ns/op   19526 B/op    306 allocs/op
BenchmarkListDir-8                  107212    11246 ns/op    6594 B/op    102 allocs/op
BenchmarkListDir_HighFrequency-8     78188    15330 ns/op    8002 B/op    126 allocs/op
BenchmarkList_LargeStore-8            9544   121462 ns/op   65845 B/op   1002 allocs/op
BenchmarkListDir_LargeStore-8        10000   118759 ns/op   65846 B/op   1002 allocs/op
```

## Test plan

- [x] All unit tests pass
- [x] Full test suite passes with race detection
- [x] Build succeeds
- [x] Benchmarks run successfully

Fixes #449