### PR TITLE
feat: add Consul and Redis containers for E2E tests

### DIFF
--- a/test/e2e/containers/consul.go
+++ b/test/e2e/containers/consul.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+package containers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	consulImage = "hashicorp/consul:1.15"
+	consulPort  = "8500/tcp"
+)
+
+// ConsulContainer manages a Consul container for E2E tests.
+type ConsulContainer struct {
+	container testcontainers.Container
+	client    *api.Client
+	endpoint  string
+}
+
+// NewConsulContainer creates a new ConsulContainer instance.
+func NewConsulContainer() *ConsulContainer {
+	return &ConsulContainer{}
+}
+
+// Start starts the Consul container and initializes the client.
+func (c *ConsulContainer) Start(ctx context.Context) error {
+	req := testcontainers.ContainerRequest{
+		Image:        consulImage,
+		ExposedPorts: []string{consulPort},
+		Cmd:          []string{"agent", "-dev", "-client=0.0.0.0"},
+		WaitingFor:   wait.ForHTTP("/v1/status/leader").WithPort("8500/tcp").WithStartupTimeout(30 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start consul container: %w", err)
+	}
+	c.container = container
+
+	// Get the mapped port
+	mappedPort, err := container.MappedPort(ctx, "8500")
+	if err != nil {
+		return fmt.Errorf("failed to get mapped port: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get container host: %w", err)
+	}
+
+	c.endpoint = fmt.Sprintf("%s:%s", host, mappedPort.Port())
+
+	// Create Consul client
+	config := api.DefaultConfig()
+	config.Address = c.endpoint
+	c.client, err = api.NewClient(config)
+	if err != nil {
+		return fmt.Errorf("failed to create consul client: %w", err)
+	}
+
+	// Verify connection
+	healthCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	opts := &api.QueryOptions{}
+	opts = opts.WithContext(healthCtx)
+	_, _, err = c.client.KV().List("", opts)
+	if err != nil {
+		return fmt.Errorf("failed to verify consul connection: %w", err)
+	}
+
+	return nil
+}
+
+// Stop stops the Consul container.
+func (c *ConsulContainer) Stop(ctx context.Context) error {
+	// Consul API client doesn't have a Close method
+	c.client = nil
+
+	if c.container != nil {
+		if err := c.container.Terminate(ctx); err != nil {
+			return fmt.Errorf("failed to terminate consul container: %w", err)
+		}
+		c.container = nil
+	}
+
+	return nil
+}
+
+// Endpoint returns the Consul connection endpoint.
+func (c *ConsulContainer) Endpoint(ctx context.Context) (string, error) {
+	if c.endpoint == "" {
+		return "", fmt.Errorf("consul container not started")
+	}
+	return c.endpoint, nil
+}
+
+// SetValue sets a key-value pair in Consul.
+// Keys should be provided with leading slash (e.g., "/test/value")
+// which will be converted to Consul format (e.g., "test/value").
+func (c *ConsulContainer) SetValue(ctx context.Context, key, value string) error {
+	if c.client == nil {
+		return fmt.Errorf("consul client not initialized")
+	}
+
+	// Remove leading slash for Consul
+	consulKey := strings.TrimPrefix(key, "/")
+
+	opts := &api.WriteOptions{}
+	opts = opts.WithContext(ctx)
+
+	_, err := c.client.KV().Put(&api.KVPair{
+		Key:   consulKey,
+		Value: []byte(value),
+	}, opts)
+	if err != nil {
+		return fmt.Errorf("failed to set value for key %s: %w", key, err)
+	}
+
+	return nil
+}
+
+// DeleteValue deletes a key from Consul.
+func (c *ConsulContainer) DeleteValue(ctx context.Context, key string) error {
+	if c.client == nil {
+		return fmt.Errorf("consul client not initialized")
+	}
+
+	// Remove leading slash for Consul
+	consulKey := strings.TrimPrefix(key, "/")
+
+	opts := &api.WriteOptions{}
+	opts = opts.WithContext(ctx)
+
+	_, err := c.client.KV().Delete(consulKey, opts)
+	if err != nil {
+		return fmt.Errorf("failed to delete key %s: %w", key, err)
+	}
+
+	return nil
+}
+
+// BackendName returns "consul".
+func (c *ConsulContainer) BackendName() string {
+	return "consul"
+}

--- a/test/e2e/containers/redis.go
+++ b/test/e2e/containers/redis.go
@@ -1,0 +1,147 @@
+//go:build e2e
+
+package containers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	redisImage = "redis:7-alpine"
+	redisPort  = "6379/tcp"
+)
+
+// RedisContainer manages a Redis container for E2E tests.
+type RedisContainer struct {
+	container testcontainers.Container
+	client    *redis.Client
+	endpoint  string
+}
+
+// NewRedisContainer creates a new RedisContainer instance.
+func NewRedisContainer() *RedisContainer {
+	return &RedisContainer{}
+}
+
+// Start starts the Redis container and initializes the client.
+func (r *RedisContainer) Start(ctx context.Context) error {
+	// Start Redis with keyspace notifications enabled for watch mode
+	// KEA = Keyspace events for all commands (K=keyspace, E=keyevent, A=all)
+	req := testcontainers.ContainerRequest{
+		Image:        redisImage,
+		ExposedPorts: []string{redisPort},
+		Cmd:          []string{"redis-server", "--notify-keyspace-events", "KEA"},
+		WaitingFor:   wait.ForLog("Ready to accept connections").WithStartupTimeout(30 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start redis container: %w", err)
+	}
+	r.container = container
+
+	// Get the mapped port
+	mappedPort, err := container.MappedPort(ctx, "6379")
+	if err != nil {
+		return fmt.Errorf("failed to get mapped port: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get container host: %w", err)
+	}
+
+	r.endpoint = fmt.Sprintf("%s:%s", host, mappedPort.Port())
+
+	// Create Redis client
+	r.client = redis.NewClient(&redis.Options{
+		Addr:         r.endpoint,
+		DialTimeout:  5 * time.Second,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	})
+
+	// Verify connection
+	healthCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := r.client.Ping(healthCtx).Err(); err != nil {
+		return fmt.Errorf("failed to verify redis connection: %w", err)
+	}
+
+	return nil
+}
+
+// Stop stops the Redis container and closes the client.
+func (r *RedisContainer) Stop(ctx context.Context) error {
+	if r.client != nil {
+		if err := r.client.Close(); err != nil {
+			return fmt.Errorf("failed to close redis client: %w", err)
+		}
+		r.client = nil
+	}
+
+	if r.container != nil {
+		if err := r.container.Terminate(ctx); err != nil {
+			return fmt.Errorf("failed to terminate redis container: %w", err)
+		}
+		r.container = nil
+	}
+
+	return nil
+}
+
+// Endpoint returns the Redis connection endpoint.
+func (r *RedisContainer) Endpoint(ctx context.Context) (string, error) {
+	if r.endpoint == "" {
+		return "", fmt.Errorf("redis container not started")
+	}
+	return r.endpoint, nil
+}
+
+// SetValue sets a key-value pair in Redis.
+// Keys are stored as-is (e.g., "/test/value").
+func (r *RedisContainer) SetValue(ctx context.Context, key, value string) error {
+	if r.client == nil {
+		return fmt.Errorf("redis client not initialized")
+	}
+
+	setCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := r.client.Set(setCtx, key, value, 0).Err(); err != nil {
+		return fmt.Errorf("failed to set value for key %s: %w", key, err)
+	}
+
+	return nil
+}
+
+// DeleteValue deletes a key from Redis.
+func (r *RedisContainer) DeleteValue(ctx context.Context, key string) error {
+	if r.client == nil {
+		return fmt.Errorf("redis client not initialized")
+	}
+
+	delCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := r.client.Del(delCtx, key).Err(); err != nil {
+		return fmt.Errorf("failed to delete key %s: %w", key, err)
+	}
+
+	return nil
+}
+
+// BackendName returns "redis".
+func (r *RedisContainer) BackendName() string {
+	return "redis"
+}

--- a/test/e2e/watch/consul_test.go
+++ b/test/e2e/watch/consul_test.go
@@ -1,0 +1,267 @@
+//go:build e2e
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/abtreece/confd/test/e2e/containers"
+	"github.com/abtreece/confd/test/e2e/testenv"
+)
+
+// TestConsulWatch_BasicChange verifies that the WatchProcessor detects
+// a single key change in Consul and updates the output file.
+func TestConsulWatch_BasicChange(t *testing.T) {
+	// Use separate contexts for container lifecycle and processor
+	containerCtx := context.Background()
+
+	// Setup Consul container
+	container := containers.NewConsulContainer()
+	env := testenv.NewE2ETestEnv(t, container)
+
+	if err := env.Setup(containerCtx); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(containerCtx); err != nil {
+			t.Logf("Warning: failed to teardown: %v", err)
+		}
+	}()
+
+	// Set initial value in Consul
+	if err := env.SetBackendValue(containerCtx, "/test/value", "initial"); err != nil {
+		t.Fatalf("Failed to set initial value: %v", err)
+	}
+
+	// Create template
+	env.WriteTemplate("test.tmpl", `value={{ getv "/test/value" }}`)
+
+	// Create config
+	destPath := env.DestPath("output.txt")
+	configContent := fmt.Sprintf(`[template]
+src = "test.tmpl"
+dest = "%s"
+keys = ["/test"]
+prefix = "/"
+`, destPath)
+	env.WriteConfig("test.toml", configContent)
+
+	// Create cancellable context for processor
+	processorCtx, cancelProcessor := context.WithCancel(containerCtx)
+
+	// Create and start watch processor
+	processor, _, doneChan, errChan, err := env.CreateWatchProcessor(processorCtx)
+	if err != nil {
+		t.Fatalf("Failed to create watch processor: %v", err)
+	}
+
+	// Start processor in goroutine
+	go processor.Process()
+
+	// Wait for initial output
+	if err := testenv.WaitForFile(t, destPath, 10*time.Second, "value=initial"); err != nil {
+		t.Fatalf("Initial output not created: %v", err)
+	}
+
+	// Update value in Consul
+	time.Sleep(200 * time.Millisecond) // Allow watch to settle
+	if err := env.SetBackendValue(containerCtx, "/test/value", "updated"); err != nil {
+		t.Fatalf("Failed to update value: %v", err)
+	}
+
+	// Wait for updated output
+	content, err := testenv.WaitForFileUpdate(t, destPath, 10*time.Second, "value=initial")
+	if err != nil {
+		t.Fatalf("Output not updated after change: %v", err)
+	}
+
+	if content != "value=updated" {
+		t.Errorf("Expected 'value=updated', got %q", content)
+	}
+
+	// Check for errors (drain any non-blocking errors)
+	select {
+	case err := <-errChan:
+		t.Errorf("Unexpected error from processor: %v", err)
+	default:
+	}
+
+	// Cleanup - use context cancellation for reliable shutdown
+	cancelProcessor()
+	select {
+	case <-doneChan:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Error("Processor did not stop within timeout")
+	}
+}
+
+// TestConsulWatch_MultipleUpdates verifies that the WatchProcessor correctly
+// handles multiple sequential updates to the same key.
+func TestConsulWatch_MultipleUpdates(t *testing.T) {
+	// Use separate contexts for container lifecycle and processor
+	containerCtx := context.Background()
+
+	// Setup Consul container
+	container := containers.NewConsulContainer()
+	env := testenv.NewE2ETestEnv(t, container)
+
+	if err := env.Setup(containerCtx); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(containerCtx); err != nil {
+			t.Logf("Warning: failed to teardown: %v", err)
+		}
+	}()
+
+	// Set initial value
+	if err := env.SetBackendValue(containerCtx, "/counter/value", "0"); err != nil {
+		t.Fatalf("Failed to set initial value: %v", err)
+	}
+
+	// Create template
+	env.WriteTemplate("counter.tmpl", `count={{ getv "/counter/value" }}`)
+
+	// Create config
+	destPath := env.DestPath("counter.txt")
+	configContent := fmt.Sprintf(`[template]
+src = "counter.tmpl"
+dest = "%s"
+keys = ["/counter"]
+prefix = "/"
+`, destPath)
+	env.WriteConfig("counter.toml", configContent)
+
+	// Create cancellable context for processor
+	processorCtx, cancelProcessor := context.WithCancel(containerCtx)
+
+	// Create and start watch processor
+	processor, _, doneChan, errChan, err := env.CreateWatchProcessor(processorCtx)
+	if err != nil {
+		t.Fatalf("Failed to create watch processor: %v", err)
+	}
+
+	go processor.Process()
+
+	// Wait for initial output
+	if err := testenv.WaitForFile(t, destPath, 10*time.Second, "count=0"); err != nil {
+		t.Fatalf("Initial output not created: %v", err)
+	}
+
+	// Update multiple times
+	for i := 1; i <= 3; i++ {
+		time.Sleep(300 * time.Millisecond) // Allow watch to detect previous change
+
+		previousValue := fmt.Sprintf("count=%d", i-1)
+		newValue := fmt.Sprintf("%d", i)
+		expectedContent := fmt.Sprintf("count=%d", i)
+
+		if err := env.SetBackendValue(containerCtx, "/counter/value", newValue); err != nil {
+			t.Fatalf("Failed to set value %d: %v", i, err)
+		}
+
+		content, err := testenv.WaitForFileUpdate(t, destPath, 10*time.Second, previousValue)
+		if err != nil {
+			t.Fatalf("Output not updated for value %d: %v", i, err)
+		}
+
+		if content != expectedContent {
+			t.Errorf("Update %d: expected %q, got %q", i, expectedContent, content)
+		}
+	}
+
+	// Check for errors
+	select {
+	case err := <-errChan:
+		t.Errorf("Unexpected error from processor: %v", err)
+	default:
+	}
+
+	// Cleanup - use context cancellation for reliable shutdown
+	cancelProcessor()
+	select {
+	case <-doneChan:
+	case <-time.After(5 * time.Second):
+		t.Error("Processor did not stop within timeout")
+	}
+}
+
+// TestConsulWatch_GracefulShutdown verifies that the WatchProcessor
+// shuts down gracefully when the context is cancelled.
+func TestConsulWatch_GracefulShutdown(t *testing.T) {
+	// Use a separate context for container lifecycle
+	containerCtx := context.Background()
+
+	// Setup Consul container
+	container := containers.NewConsulContainer()
+	env := testenv.NewE2ETestEnv(t, container)
+
+	if err := env.Setup(containerCtx); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(containerCtx); err != nil {
+			t.Logf("Warning: failed to teardown: %v", err)
+		}
+	}()
+
+	// Set initial value
+	if err := env.SetBackendValue(containerCtx, "/shutdown/test", "running"); err != nil {
+		t.Fatalf("Failed to set initial value: %v", err)
+	}
+
+	// Create template
+	env.WriteTemplate("shutdown.tmpl", `status={{ getv "/shutdown/test" }}`)
+
+	// Create config
+	destPath := env.DestPath("shutdown.txt")
+	configContent := fmt.Sprintf(`[template]
+src = "shutdown.tmpl"
+dest = "%s"
+keys = ["/shutdown"]
+prefix = "/"
+`, destPath)
+	env.WriteConfig("shutdown.toml", configContent)
+
+	// Create cancellable context for processor
+	processorCtx, cancelProcessor := context.WithCancel(containerCtx)
+
+	// Create watch processor with cancellable context
+	processor, _, doneChan, errChan, err := env.CreateWatchProcessor(processorCtx)
+	if err != nil {
+		t.Fatalf("Failed to create watch processor: %v", err)
+	}
+
+	// Start processor
+	go processor.Process()
+
+	// Wait for initial output
+	if err := testenv.WaitForFile(t, destPath, 10*time.Second, "status=running"); err != nil {
+		t.Fatalf("Initial output not created: %v", err)
+	}
+
+	// Cancel the processor context
+	cancelProcessor()
+
+	// Verify doneChan is closed (processor stopped)
+	select {
+	case <-doneChan:
+		// Success - processor shut down cleanly
+	case <-time.After(5 * time.Second):
+		t.Error("Processor did not shut down within timeout after context cancellation")
+	}
+
+	// Check for any errors (context cancellation is expected)
+	select {
+	case err := <-errChan:
+		// Context cancellation errors are acceptable
+		if err != nil && err != context.Canceled {
+			t.Logf("Error during shutdown (may be expected): %v", err)
+		}
+	default:
+	}
+}

--- a/test/e2e/watch/redis_test.go
+++ b/test/e2e/watch/redis_test.go
@@ -1,0 +1,267 @@
+//go:build e2e
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/abtreece/confd/test/e2e/containers"
+	"github.com/abtreece/confd/test/e2e/testenv"
+)
+
+// TestRedisWatch_BasicChange verifies that the WatchProcessor detects
+// a single key change in Redis and updates the output file.
+func TestRedisWatch_BasicChange(t *testing.T) {
+	// Use separate contexts for container lifecycle and processor
+	containerCtx := context.Background()
+
+	// Setup Redis container
+	container := containers.NewRedisContainer()
+	env := testenv.NewE2ETestEnv(t, container)
+
+	if err := env.Setup(containerCtx); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(containerCtx); err != nil {
+			t.Logf("Warning: failed to teardown: %v", err)
+		}
+	}()
+
+	// Set initial value in Redis
+	if err := env.SetBackendValue(containerCtx, "/test/value", "initial"); err != nil {
+		t.Fatalf("Failed to set initial value: %v", err)
+	}
+
+	// Create template
+	env.WriteTemplate("test.tmpl", `value={{ getv "/test/value" }}`)
+
+	// Create config
+	destPath := env.DestPath("output.txt")
+	configContent := fmt.Sprintf(`[template]
+src = "test.tmpl"
+dest = "%s"
+keys = ["/test"]
+prefix = "/"
+`, destPath)
+	env.WriteConfig("test.toml", configContent)
+
+	// Create cancellable context for processor
+	processorCtx, cancelProcessor := context.WithCancel(containerCtx)
+
+	// Create and start watch processor
+	processor, _, doneChan, errChan, err := env.CreateWatchProcessor(processorCtx)
+	if err != nil {
+		t.Fatalf("Failed to create watch processor: %v", err)
+	}
+
+	// Start processor in goroutine
+	go processor.Process()
+
+	// Wait for initial output
+	if err := testenv.WaitForFile(t, destPath, 10*time.Second, "value=initial"); err != nil {
+		t.Fatalf("Initial output not created: %v", err)
+	}
+
+	// Update value in Redis
+	time.Sleep(500 * time.Millisecond) // Allow watch to settle (Redis PubSub needs time)
+	if err := env.SetBackendValue(containerCtx, "/test/value", "updated"); err != nil {
+		t.Fatalf("Failed to update value: %v", err)
+	}
+
+	// Wait for updated output
+	content, err := testenv.WaitForFileUpdate(t, destPath, 10*time.Second, "value=initial")
+	if err != nil {
+		t.Fatalf("Output not updated after change: %v", err)
+	}
+
+	if content != "value=updated" {
+		t.Errorf("Expected 'value=updated', got %q", content)
+	}
+
+	// Check for errors (drain any non-blocking errors)
+	select {
+	case err := <-errChan:
+		t.Errorf("Unexpected error from processor: %v", err)
+	default:
+	}
+
+	// Cleanup - use context cancellation for reliable shutdown
+	cancelProcessor()
+	select {
+	case <-doneChan:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Error("Processor did not stop within timeout")
+	}
+}
+
+// TestRedisWatch_MultipleUpdates verifies that the WatchProcessor correctly
+// handles multiple sequential updates to the same key.
+func TestRedisWatch_MultipleUpdates(t *testing.T) {
+	// Use separate contexts for container lifecycle and processor
+	containerCtx := context.Background()
+
+	// Setup Redis container
+	container := containers.NewRedisContainer()
+	env := testenv.NewE2ETestEnv(t, container)
+
+	if err := env.Setup(containerCtx); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(containerCtx); err != nil {
+			t.Logf("Warning: failed to teardown: %v", err)
+		}
+	}()
+
+	// Set initial value
+	if err := env.SetBackendValue(containerCtx, "/counter/value", "0"); err != nil {
+		t.Fatalf("Failed to set initial value: %v", err)
+	}
+
+	// Create template
+	env.WriteTemplate("counter.tmpl", `count={{ getv "/counter/value" }}`)
+
+	// Create config
+	destPath := env.DestPath("counter.txt")
+	configContent := fmt.Sprintf(`[template]
+src = "counter.tmpl"
+dest = "%s"
+keys = ["/counter"]
+prefix = "/"
+`, destPath)
+	env.WriteConfig("counter.toml", configContent)
+
+	// Create cancellable context for processor
+	processorCtx, cancelProcessor := context.WithCancel(containerCtx)
+
+	// Create and start watch processor
+	processor, _, doneChan, errChan, err := env.CreateWatchProcessor(processorCtx)
+	if err != nil {
+		t.Fatalf("Failed to create watch processor: %v", err)
+	}
+
+	go processor.Process()
+
+	// Wait for initial output
+	if err := testenv.WaitForFile(t, destPath, 10*time.Second, "count=0"); err != nil {
+		t.Fatalf("Initial output not created: %v", err)
+	}
+
+	// Update multiple times
+	for i := 1; i <= 3; i++ {
+		time.Sleep(500 * time.Millisecond) // Allow watch to detect previous change (Redis needs more time)
+
+		previousValue := fmt.Sprintf("count=%d", i-1)
+		newValue := fmt.Sprintf("%d", i)
+		expectedContent := fmt.Sprintf("count=%d", i)
+
+		if err := env.SetBackendValue(containerCtx, "/counter/value", newValue); err != nil {
+			t.Fatalf("Failed to set value %d: %v", i, err)
+		}
+
+		content, err := testenv.WaitForFileUpdate(t, destPath, 10*time.Second, previousValue)
+		if err != nil {
+			t.Fatalf("Output not updated for value %d: %v", i, err)
+		}
+
+		if content != expectedContent {
+			t.Errorf("Update %d: expected %q, got %q", i, expectedContent, content)
+		}
+	}
+
+	// Check for errors
+	select {
+	case err := <-errChan:
+		t.Errorf("Unexpected error from processor: %v", err)
+	default:
+	}
+
+	// Cleanup - use context cancellation for reliable shutdown
+	cancelProcessor()
+	select {
+	case <-doneChan:
+	case <-time.After(5 * time.Second):
+		t.Error("Processor did not stop within timeout")
+	}
+}
+
+// TestRedisWatch_GracefulShutdown verifies that the WatchProcessor
+// shuts down gracefully when the context is cancelled.
+func TestRedisWatch_GracefulShutdown(t *testing.T) {
+	// Use a separate context for container lifecycle
+	containerCtx := context.Background()
+
+	// Setup Redis container
+	container := containers.NewRedisContainer()
+	env := testenv.NewE2ETestEnv(t, container)
+
+	if err := env.Setup(containerCtx); err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+	defer func() {
+		if err := env.Teardown(containerCtx); err != nil {
+			t.Logf("Warning: failed to teardown: %v", err)
+		}
+	}()
+
+	// Set initial value
+	if err := env.SetBackendValue(containerCtx, "/shutdown/test", "running"); err != nil {
+		t.Fatalf("Failed to set initial value: %v", err)
+	}
+
+	// Create template
+	env.WriteTemplate("shutdown.tmpl", `status={{ getv "/shutdown/test" }}`)
+
+	// Create config
+	destPath := env.DestPath("shutdown.txt")
+	configContent := fmt.Sprintf(`[template]
+src = "shutdown.tmpl"
+dest = "%s"
+keys = ["/shutdown"]
+prefix = "/"
+`, destPath)
+	env.WriteConfig("shutdown.toml", configContent)
+
+	// Create cancellable context for processor
+	processorCtx, cancelProcessor := context.WithCancel(containerCtx)
+
+	// Create watch processor with cancellable context
+	processor, _, doneChan, errChan, err := env.CreateWatchProcessor(processorCtx)
+	if err != nil {
+		t.Fatalf("Failed to create watch processor: %v", err)
+	}
+
+	// Start processor
+	go processor.Process()
+
+	// Wait for initial output
+	if err := testenv.WaitForFile(t, destPath, 10*time.Second, "status=running"); err != nil {
+		t.Fatalf("Initial output not created: %v", err)
+	}
+
+	// Cancel the processor context
+	cancelProcessor()
+
+	// Verify doneChan is closed (processor stopped)
+	select {
+	case <-doneChan:
+		// Success - processor shut down cleanly
+	case <-time.After(5 * time.Second):
+		t.Error("Processor did not shut down within timeout after context cancellation")
+	}
+
+	// Check for any errors (context cancellation is expected)
+	select {
+	case err := <-errChan:
+		// Context cancellation errors are acceptable
+		if err != nil && err != context.Canceled {
+			t.Logf("Error during shutdown (may be expected): %v", err)
+		}
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

- Add Consul container implementation for E2E tests
- Add Redis container implementation for E2E tests
- Add 6 new watch mode tests (3 Consul, 3 Redis)

## New Files

| File | Purpose |
|------|---------|
| `test/e2e/containers/consul.go` | Consul container using `hashicorp/consul:1.15` |
| `test/e2e/containers/redis.go` | Redis container with keyspace notifications enabled |
| `test/e2e/watch/consul_test.go` | Consul watch mode tests |
| `test/e2e/watch/redis_test.go` | Redis watch mode tests |

## Tests Added

| Backend | Test | Description |
|---------|------|-------------|
| Consul | `TestConsulWatch_BasicChange` | Single key change detection |
| Consul | `TestConsulWatch_MultipleUpdates` | Multiple sequential updates |
| Consul | `TestConsulWatch_GracefulShutdown` | Context cancellation shutdown |
| Redis | `TestRedisWatch_BasicChange` | Single key change detection |
| Redis | `TestRedisWatch_MultipleUpdates` | Multiple sequential updates |
| Redis | `TestRedisWatch_GracefulShutdown` | Context cancellation shutdown |

## Total E2E Test Coverage

| Backend | Tests |
|---------|-------|
| etcd | 4 |
| Consul | 3 |
| Redis | 3 |
| **Total** | **10** |

## Test plan

- [x] All 10 E2E tests pass locally
- [x] Existing unit tests pass
- [ ] CI E2E workflow runs successfully