### PR TITLE
feat: add E2E tests for per-resource backend, timeouts, and SIGHUP reload

### DIFF
--- a/docs/e2e-test-plan.md
+++ b/docs/e2e-test-plan.md
@@ -10,8 +10,9 @@ This document outlines additional E2E tests to be implemented for confd, buildin
 |------|-------|----------|
 | Watch Mode | etcd, Consul, Redis, Zookeeper basic/multi-update/multi-key, debounce, batch | `test/e2e/watch/` |
 | Reconnection | Backend restart, graceful degradation | `test/e2e/watch/reconnect_test.go` |
-| Operations | Health endpoints, Prometheus metrics, signals | `test/e2e/operations/` |
-| Features | Commands, Permissions, Functions, Includes, Failure Modes | `test/e2e/features/` |
+| Operations | Health endpoints, Prometheus metrics, signals, SIGHUP reload | `test/e2e/operations/` |
+| Features | Commands, Permissions, Functions, Includes, Failure Modes, Per-Resource Backend | `test/e2e/features/` |
+| Resilience | Command timeouts, global/per-resource timeout precedence | `test/e2e/resilience/` |
 
 ## Proposed New E2E Tests
 
@@ -247,12 +248,18 @@ test/e2e/
 - Implemented `include_test.go` (6 tests: BasicInclude, SubdirectoryInclude, NestedInclude, CycleDetection, MaxDepth, MissingTemplate)
 - Implemented `failuremode_test.go` (4 tests: BestEffort_ContinuesOnError, FailFast_StopsOnError, ExitCodes, ErrorAggregation)
 
+### ✅ Completed: Sprint 4 - Advanced Scenarios
+- Implemented `per_resource_backend_test.go` (3 tests: OverrideGlobal, MixedBackends, Precedence)
+- Created `test/e2e/resilience/` package with `doc.go`
+- Implemented `timeout_test.go` (6 tests: CheckCmd_EnforcesTimeout, ReloadCmd_EnforcesTimeout, CheckCmd_GlobalDefault, PerResourceOverridesGlobal, CheckCmd_ZeroMeansNoTimeout, MultipleTemplates_IndependentTimeouts)
+- Implemented `reload_test.go` (5 tests: AddNewTemplate, UpdatedTemplateReprocessed, RemovedTemplateStopsProcessing, ModifiedConfigReprocessed, MultipleSIGHUPs)
+
 ### Planned Sprints
 
-#### Sprint 4: Advanced Scenarios
-1. Implement per_resource_backend_test.go (3 tests)
-2. Implement timeout_test.go
-3. Implement reload_test.go
+#### Sprint 5: Concurrency (Optional)
+1. Implement concurrent_test.go (multiple templates updating simultaneously)
+2. File lock handling tests
+3. Template cache consistency under load
 
 ## Shared Test Helpers
 

--- a/test/e2e/features/per_resource_backend_test.go
+++ b/test/e2e/features/per_resource_backend_test.go
@@ -1,0 +1,268 @@
+//go:build e2e
+
+package features
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/abtreece/confd/test/e2e/operations"
+)
+
+// TestPerResourceBackend_OverrideGlobal verifies that a template can specify
+// its own backend (file) that overrides the global backend (env).
+func TestPerResourceBackend_OverrideGlobal(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("secrets.conf")
+
+	// Create file backend data in a subdirectory
+	fileBackendDir := filepath.Join(env.BaseDir, "file-backend")
+	if err := os.MkdirAll(fileBackendDir, 0755); err != nil {
+		t.Fatalf("Failed to create file backend directory: %v", err)
+	}
+
+	// Write YAML file for file backend
+	yamlPath := filepath.Join(fileBackendDir, "secrets.yaml")
+	yamlContent := `secrets:
+  database:
+    password: super-secret-password
+  api:
+    key: api-key-12345
+`
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	// Write template that uses keys from file backend
+	env.WriteTemplate("secrets.tmpl", `[database]
+password = {{ getv "/secrets/database/password" }}
+
+[api]
+key = {{ getv "/secrets/api/key" }}
+`)
+
+	// Write config with per-resource backend override
+	env.WriteConfig("secrets.toml", fmt.Sprintf(`[template]
+src = "secrets.tmpl"
+dest = "%s"
+keys = ["/secrets"]
+
+[backend]
+backend = "file"
+file = ["%s"]
+`, destPath, yamlPath))
+
+	// Run confd with env as global backend (but template uses file backend)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	// Set an env variable that won't be used (global backend is env, but template overrides to file)
+	confd.SetEnv("UNUSED_KEY", "unused-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	exitCode, err := confd.Wait()
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0, got %d", exitCode)
+	}
+
+	// Verify output
+	content, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("Destination file not created: %v", err)
+	}
+
+	expected := `[database]
+password = super-secret-password
+
+[api]
+key = api-key-12345
+`
+	if string(content) != expected {
+		t.Errorf("Content mismatch.\nExpected:\n%s\nGot:\n%s", expected, string(content))
+	}
+}
+
+// TestPerResourceBackend_MixedBackends verifies that multiple templates can use
+// different backends in a single confd run.
+func TestPerResourceBackend_MixedBackends(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	appDestPath := env.DestPath("app.conf")
+	secretsDestPath := env.DestPath("secrets.conf")
+
+	// Create file backend data
+	fileBackendDir := filepath.Join(env.BaseDir, "file-backend")
+	if err := os.MkdirAll(fileBackendDir, 0755); err != nil {
+		t.Fatalf("Failed to create file backend directory: %v", err)
+	}
+
+	yamlPath := filepath.Join(fileBackendDir, "secrets.yaml")
+	yamlContent := `secrets:
+  database:
+    password: db-password-from-file
+`
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	// Write template that uses env backend (global)
+	env.WriteTemplate("app.tmpl", `[app]
+name = {{ getv "/app/name" }}
+version = {{ getv "/app/version" }}
+`)
+
+	// Write template that uses file backend (per-resource override)
+	env.WriteTemplate("secrets.tmpl", `[database]
+password = {{ getv "/secrets/database/password" }}
+`)
+
+	// Write config for app template (uses global env backend - no [backend] section)
+	env.WriteConfig("app.toml", fmt.Sprintf(`[template]
+src = "app.tmpl"
+dest = "%s"
+keys = ["/app"]
+`, appDestPath))
+
+	// Write config for secrets template (uses file backend via per-resource override)
+	env.WriteConfig("secrets.toml", fmt.Sprintf(`[template]
+src = "secrets.tmpl"
+dest = "%s"
+keys = ["/secrets"]
+
+[backend]
+backend = "file"
+file = ["%s"]
+`, secretsDestPath, yamlPath))
+
+	// Run confd with env as global backend
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("APP_NAME", "myapp")
+	confd.SetEnv("APP_VERSION", "1.0.0")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	exitCode, err := confd.Wait()
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0, got %d", exitCode)
+	}
+
+	// Verify app.conf (from env backend)
+	appContent, err := os.ReadFile(appDestPath)
+	if err != nil {
+		t.Fatalf("app.conf not created: %v", err)
+	}
+
+	expectedApp := `[app]
+name = myapp
+version = 1.0.0
+`
+	if string(appContent) != expectedApp {
+		t.Errorf("app.conf content mismatch.\nExpected:\n%s\nGot:\n%s", expectedApp, string(appContent))
+	}
+
+	// Verify secrets.conf (from file backend)
+	secretsContent, err := os.ReadFile(secretsDestPath)
+	if err != nil {
+		t.Fatalf("secrets.conf not created: %v", err)
+	}
+
+	expectedSecrets := `[database]
+password = db-password-from-file
+`
+	if string(secretsContent) != expectedSecrets {
+		t.Errorf("secrets.conf content mismatch.\nExpected:\n%s\nGot:\n%s", expectedSecrets, string(secretsContent))
+	}
+}
+
+// TestPerResourceBackend_Precedence verifies that per-resource backend
+// configuration takes precedence over global backend for the same data.
+func TestPerResourceBackend_Precedence(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("config.conf")
+
+	// Create file backend data with a specific value
+	fileBackendDir := filepath.Join(env.BaseDir, "file-backend")
+	if err := os.MkdirAll(fileBackendDir, 0755); err != nil {
+		t.Fatalf("Failed to create file backend directory: %v", err)
+	}
+
+	yamlPath := filepath.Join(fileBackendDir, "config.yaml")
+	yamlContent := `config:
+  source: file-backend
+`
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file: %v", err)
+	}
+
+	// Write template
+	env.WriteTemplate("config.tmpl", `source = {{ getv "/config/source" }}
+`)
+
+	// Write config with per-resource backend override
+	// Even though we're running with env backend globally, this template uses file
+	env.WriteConfig("config.toml", fmt.Sprintf(`[template]
+src = "config.tmpl"
+dest = "%s"
+keys = ["/config"]
+
+[backend]
+backend = "file"
+file = ["%s"]
+`, destPath, yamlPath))
+
+	// Run confd with env as global backend
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	// Set an env variable with the same key path - should NOT be used
+	// because per-resource file backend takes precedence
+	confd.SetEnv("CONFIG_SOURCE", "env-backend")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	exitCode, err := confd.Wait()
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0, got %d", exitCode)
+	}
+
+	// Verify output uses file backend value, not env backend value
+	content, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("Destination file not created: %v", err)
+	}
+
+	expected := "source = file-backend\n"
+	if string(content) != expected {
+		t.Errorf("Per-resource backend should take precedence.\nExpected: %q\nGot: %q", expected, string(content))
+	}
+}

--- a/test/e2e/operations/reload_test.go
+++ b/test/e2e/operations/reload_test.go
@@ -1,0 +1,364 @@
+//go:build e2e
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestReload_AddNewTemplate verifies that a new template added to conf.d
+// is discovered and processed after SIGHUP.
+func TestReload_AddNewTemplate(t *testing.T) {
+	env := NewTestEnv(t)
+	originalDestPath := env.DestPath("original.conf")
+	newDestPath := env.DestPath("new.conf")
+
+	// Write original template
+	env.WriteTemplate("original.tmpl", `original: {{ getv "/original" }}
+`)
+
+	// Write original config
+	env.WriteConfig("original.toml", fmt.Sprintf(`[template]
+src = "original.tmpl"
+dest = "%s"
+keys = ["/original"]
+`, originalDestPath))
+
+	// Start confd in interval mode
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	confd := NewConfdBinary(t)
+	confd.SetEnv("ORIGINAL", "original-value")
+	confd.SetEnv("NEW", "new-value")
+	err := confd.Start(ctx, "env", "--interval", "2", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+	defer confd.Stop()
+
+	// Wait for initial config file to be created
+	if err := WaitForFile(t, originalDestPath, 10*time.Second, "original: original-value\n"); err != nil {
+		t.Fatalf("Initial config file not created: %v", err)
+	}
+
+	// Verify new template doesn't exist yet
+	if _, err := os.Stat(newDestPath); err == nil {
+		t.Fatal("New template should not exist before being added")
+	}
+
+	// Add new template and config
+	env.WriteTemplate("new.tmpl", `new: {{ getv "/new" }}
+`)
+	env.WriteConfig("new.toml", fmt.Sprintf(`[template]
+src = "new.tmpl"
+dest = "%s"
+keys = ["/new"]
+`, newDestPath))
+
+	// Send SIGHUP to trigger reload
+	if err := confd.SendSignal(syscall.SIGHUP); err != nil {
+		t.Fatalf("Failed to send SIGHUP: %v", err)
+	}
+
+	// Wait for the new config file to be created (indicates template was discovered)
+	if err := WaitForFile(t, newDestPath, 10*time.Second, "new: new-value\n"); err != nil {
+		t.Fatalf("New template not processed after SIGHUP: %v", err)
+	}
+
+	// Verify process is still running
+	if !confd.IsRunning() {
+		t.Error("confd should continue running after SIGHUP")
+	}
+
+	// Verify original template still works
+	content, err := os.ReadFile(originalDestPath)
+	if err != nil {
+		t.Fatalf("Original config file missing: %v", err)
+	}
+	if string(content) != "original: original-value\n" {
+		t.Errorf("Original config has unexpected content: %q", string(content))
+	}
+}
+
+// TestReload_UpdatedTemplateReprocessed verifies that when a template file
+// is modified, it is reprocessed after SIGHUP.
+func TestReload_UpdatedTemplateReprocessed(t *testing.T) {
+	env := NewTestEnv(t)
+	destPath := env.DestPath("updated.conf")
+	templatePath := env.WriteTemplate("updated.tmpl", `version: 1
+key: {{ getv "/key" }}
+`)
+
+	// Write config
+	env.WriteConfig("updated.toml", fmt.Sprintf(`[template]
+src = "updated.tmpl"
+dest = "%s"
+keys = ["/key"]
+`, destPath))
+
+	// Start confd in interval mode
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	confd := NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--interval", "2", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+	defer confd.Stop()
+
+	// Wait for initial config file
+	expectedV1 := "version: 1\nkey: test-value\n"
+	if err := WaitForFile(t, destPath, 10*time.Second, expectedV1); err != nil {
+		t.Fatalf("Initial config file not created: %v", err)
+	}
+
+	// Modify the template file (bump version)
+	newTemplateContent := `version: 2
+key: {{ getv "/key" }}
+`
+	if err := os.WriteFile(templatePath, []byte(newTemplateContent), 0644); err != nil {
+		t.Fatalf("Failed to update template: %v", err)
+	}
+
+	// Send SIGHUP to trigger reload (clears template cache)
+	if err := confd.SendSignal(syscall.SIGHUP); err != nil {
+		t.Fatalf("Failed to send SIGHUP: %v", err)
+	}
+
+	// Wait for the updated template to be processed
+	expectedV2 := "version: 2\nkey: test-value\n"
+	if err := WaitForFile(t, destPath, 10*time.Second, expectedV2); err != nil {
+		t.Fatalf("Updated template not processed after SIGHUP: %v", err)
+	}
+
+	// Verify process is still running
+	if !confd.IsRunning() {
+		t.Error("confd should continue running after SIGHUP")
+	}
+}
+
+// TestReload_RemovedTemplateStopsProcessing verifies that when a template
+// config is removed from conf.d, it is no longer processed after SIGHUP.
+func TestReload_RemovedTemplateStopsProcessing(t *testing.T) {
+	env := NewTestEnv(t)
+	persistentDestPath := env.DestPath("persistent.conf")
+	removedDestPath := env.DestPath("removed.conf")
+
+	// Write templates
+	env.WriteTemplate("persistent.tmpl", `persistent: {{ getv "/persistent" }}
+`)
+	env.WriteTemplate("removed.tmpl", `removed: {{ getv "/removed" }}
+`)
+
+	// Write configs
+	env.WriteConfig("persistent.toml", fmt.Sprintf(`[template]
+src = "persistent.tmpl"
+dest = "%s"
+keys = ["/persistent"]
+`, persistentDestPath))
+
+	removedConfigPath := env.WriteConfig("removed.toml", fmt.Sprintf(`[template]
+src = "removed.tmpl"
+dest = "%s"
+keys = ["/removed"]
+`, removedDestPath))
+
+	// Start confd in interval mode
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	confd := NewConfdBinary(t)
+	confd.SetEnv("PERSISTENT", "persistent-value")
+	confd.SetEnv("REMOVED", "removed-value")
+	err := confd.Start(ctx, "env", "--interval", "2", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+	defer confd.Stop()
+
+	// Wait for both config files to be created
+	if err := WaitForFile(t, persistentDestPath, 10*time.Second, "persistent: persistent-value\n"); err != nil {
+		t.Fatalf("Persistent config not created: %v", err)
+	}
+	if err := WaitForFile(t, removedDestPath, 10*time.Second, "removed: removed-value\n"); err != nil {
+		t.Fatalf("Removed config not created initially: %v", err)
+	}
+
+	// Delete the removed template's config file
+	if err := os.Remove(removedConfigPath); err != nil {
+		t.Fatalf("Failed to remove config file: %v", err)
+	}
+
+	// Also delete the destination file so we can verify it's not recreated
+	if err := os.Remove(removedDestPath); err != nil {
+		t.Fatalf("Failed to remove destination file: %v", err)
+	}
+
+	// Send SIGHUP to trigger reload
+	if err := confd.SendSignal(syscall.SIGHUP); err != nil {
+		t.Fatalf("Failed to send SIGHUP: %v", err)
+	}
+
+	// Wait a bit for reload to complete
+	time.Sleep(3 * time.Second)
+
+	// Verify persistent template still works
+	content, err := os.ReadFile(persistentDestPath)
+	if err != nil {
+		t.Fatalf("Persistent config should still exist: %v", err)
+	}
+	if string(content) != "persistent: persistent-value\n" {
+		t.Errorf("Persistent config has unexpected content: %q", string(content))
+	}
+
+	// Verify removed template's destination is NOT recreated
+	// (because the config was removed from conf.d)
+	if _, err := os.Stat(removedDestPath); err == nil {
+		t.Error("Removed template's destination should NOT be recreated after SIGHUP")
+	}
+
+	// Verify process is still running
+	if !confd.IsRunning() {
+		t.Error("confd should continue running after SIGHUP")
+	}
+}
+
+// TestReload_ModifiedConfigReprocessed verifies that when a template resource
+// config (.toml) is modified, it takes effect after SIGHUP.
+func TestReload_ModifiedConfigReprocessed(t *testing.T) {
+	env := NewTestEnv(t)
+	originalDestPath := env.DestPath("original-dest.conf")
+	newDestPath := env.DestPath("new-dest.conf")
+
+	// Write template
+	env.WriteTemplate("config.tmpl", `key: {{ getv "/key" }}
+`)
+
+	// Write config pointing to original destination
+	configPath := env.WriteConfig("config.toml", fmt.Sprintf(`[template]
+src = "config.tmpl"
+dest = "%s"
+keys = ["/key"]
+`, originalDestPath))
+
+	// Start confd in interval mode
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	confd := NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--interval", "2", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+	defer confd.Stop()
+
+	// Wait for initial config to be created at original location
+	if err := WaitForFile(t, originalDestPath, 10*time.Second, "key: test-value\n"); err != nil {
+		t.Fatalf("Initial config not created: %v", err)
+	}
+
+	// Modify the config to point to new destination
+	newConfig := fmt.Sprintf(`[template]
+src = "config.tmpl"
+dest = "%s"
+keys = ["/key"]
+`, newDestPath)
+	if err := os.WriteFile(configPath, []byte(newConfig), 0644); err != nil {
+		t.Fatalf("Failed to update config: %v", err)
+	}
+
+	// Send SIGHUP to trigger reload
+	if err := confd.SendSignal(syscall.SIGHUP); err != nil {
+		t.Fatalf("Failed to send SIGHUP: %v", err)
+	}
+
+	// Wait for new destination to be created
+	if err := WaitForFile(t, newDestPath, 10*time.Second, "key: test-value\n"); err != nil {
+		t.Fatalf("New destination not created after config change: %v", err)
+	}
+
+	// Verify process is still running
+	if !confd.IsRunning() {
+		t.Error("confd should continue running after SIGHUP")
+	}
+}
+
+// TestReload_MultipleSIGHUPs verifies that confd can handle multiple
+// consecutive SIGHUP signals.
+func TestReload_MultipleSIGHUPs(t *testing.T) {
+	env := NewTestEnv(t)
+	destPath := env.DestPath("multiple.conf")
+
+	// Write template
+	templatePath := filepath.Join(env.ConfDir, "templates", "multiple.tmpl")
+
+	// Write initial template
+	if err := os.WriteFile(templatePath, []byte(`version: 1
+key: {{ getv "/key" }}
+`), 0644); err != nil {
+		t.Fatalf("Failed to write initial template: %v", err)
+	}
+
+	// Write config
+	env.WriteConfig("multiple.toml", fmt.Sprintf(`[template]
+src = "multiple.tmpl"
+dest = "%s"
+keys = ["/key"]
+`, destPath))
+
+	// Start confd in interval mode
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	confd := NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--interval", "2", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+	defer confd.Stop()
+
+	// Wait for initial config
+	if err := WaitForFile(t, destPath, 10*time.Second, "version: 1\nkey: test-value\n"); err != nil {
+		t.Fatalf("Initial config not created: %v", err)
+	}
+
+	// Send multiple SIGHUPs with template updates
+	for version := 2; version <= 4; version++ {
+		// Update template
+		newContent := fmt.Sprintf(`version: %d
+key: {{ getv "/key" }}
+`, version)
+		if err := os.WriteFile(templatePath, []byte(newContent), 0644); err != nil {
+			t.Fatalf("Failed to update template to version %d: %v", version, err)
+		}
+
+		// Send SIGHUP
+		if err := confd.SendSignal(syscall.SIGHUP); err != nil {
+			t.Fatalf("Failed to send SIGHUP for version %d: %v", version, err)
+		}
+
+		// Wait for updated content
+		expected := fmt.Sprintf("version: %d\nkey: test-value\n", version)
+		if err := WaitForFile(t, destPath, 10*time.Second, expected); err != nil {
+			t.Fatalf("Template version %d not processed after SIGHUP: %v", version, err)
+		}
+
+		t.Logf("Successfully processed version %d after SIGHUP", version)
+	}
+
+	// Verify process is still running after all SIGHUPs
+	if !confd.IsRunning() {
+		t.Error("confd should continue running after multiple SIGHUPs")
+	}
+}

--- a/test/e2e/resilience/doc.go
+++ b/test/e2e/resilience/doc.go
@@ -1,0 +1,5 @@
+//go:build e2e
+
+// Package resilience contains E2E tests for confd resilience features
+// including timeout enforcement, retry behavior, and fault tolerance.
+package resilience

--- a/test/e2e/resilience/timeout_test.go
+++ b/test/e2e/resilience/timeout_test.go
@@ -1,0 +1,377 @@
+//go:build e2e
+
+package resilience
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/abtreece/confd/test/e2e/operations"
+)
+
+// TestTimeout_CheckCmd_EnforcesTimeout verifies that check_cmd times out
+// when it exceeds the configured timeout.
+func TestTimeout_CheckCmd_EnforcesTimeout(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("timeout.conf")
+
+	// Write template
+	env.WriteTemplate("timeout.tmpl", `key: {{ getv "/key" }}
+`)
+
+	// Write config with check_cmd that sleeps longer than timeout
+	// The command sleeps for 10 seconds, but timeout is 1 second
+	env.WriteConfig("timeout.toml", fmt.Sprintf(`[template]
+src = "timeout.tmpl"
+dest = "%s"
+check_cmd = "sleep 10"
+check_cmd_timeout = "1s"
+keys = ["/key"]
+`, destPath))
+
+	// Run confd
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	start := time.Now()
+	exitCode, err := confd.Wait()
+	duration := time.Since(start)
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+
+	// The command should timeout after ~1 second, not take 10 seconds
+	if duration > 5*time.Second {
+		t.Errorf("check_cmd timeout was not enforced. Expected ~1s, took %v", duration)
+	}
+
+	// Expect non-zero exit due to check_cmd timeout/failure
+	if exitCode == 0 {
+		t.Error("Expected non-zero exit code when check_cmd times out")
+	}
+
+	// Destination file should NOT be created when check_cmd fails
+	if _, err := os.Stat(destPath); err == nil {
+		t.Error("Destination file should NOT be created when check_cmd times out")
+	}
+}
+
+// TestTimeout_ReloadCmd_EnforcesTimeout verifies that reload_cmd times out
+// when it exceeds the configured timeout.
+func TestTimeout_ReloadCmd_EnforcesTimeout(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("reload-timeout.conf")
+	markerPath := filepath.Join(env.DestDir, "reload-started")
+
+	// Write template
+	env.WriteTemplate("reload.tmpl", `key: {{ getv "/key" }}
+`)
+
+	// Write config with reload_cmd that creates a marker then sleeps longer than timeout
+	// The command creates marker, sleeps for 10 seconds, but timeout is 1 second
+	env.WriteConfig("reload.toml", fmt.Sprintf(`[template]
+src = "reload.tmpl"
+dest = "%s"
+reload_cmd = "/bin/sh -c 'touch %s && sleep 10'"
+reload_cmd_timeout = "1s"
+keys = ["/key"]
+`, destPath, markerPath))
+
+	// Run confd
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	start := time.Now()
+	exitCode, err := confd.Wait()
+	duration := time.Since(start)
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+
+	// The command should timeout after ~1 second, not take 10 seconds
+	if duration > 5*time.Second {
+		t.Errorf("reload_cmd timeout was not enforced. Expected ~1s, took %v", duration)
+	}
+
+	// Note: reload_cmd runs AFTER file is written, so destination should exist
+	// even if reload_cmd times out
+	if _, err := os.Stat(destPath); os.IsNotExist(err) {
+		t.Error("Destination file should be created even when reload_cmd times out")
+	}
+
+	// The marker file should exist (proves reload_cmd started)
+	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
+		t.Error("Reload marker should exist (command should have started)")
+	}
+
+	// Exit code behavior depends on failure mode - just log it
+	t.Logf("Exit code when reload_cmd times out: %d", exitCode)
+}
+
+// TestTimeout_CheckCmd_GlobalDefault verifies that check_cmd uses
+// the global default timeout when not specified per-resource.
+func TestTimeout_CheckCmd_GlobalDefault(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("global-timeout.conf")
+
+	// Write template
+	env.WriteTemplate("global.tmpl", `key: {{ getv "/key" }}
+`)
+
+	// Write config WITHOUT per-resource timeout (will use global)
+	env.WriteConfig("global.toml", fmt.Sprintf(`[template]
+src = "global.tmpl"
+dest = "%s"
+check_cmd = "sleep 10"
+keys = ["/key"]
+`, destPath))
+
+	// Run confd with global check-cmd-timeout of 1 second
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir,
+		"--log-level", "error", "--check-cmd-timeout", "1s")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	start := time.Now()
+	_, err = confd.Wait()
+	duration := time.Since(start)
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+
+	// The global timeout should enforce the 1 second limit
+	if duration > 5*time.Second {
+		t.Errorf("Global check-cmd-timeout was not enforced. Expected ~1s, took %v", duration)
+	}
+
+	// Destination should NOT be created
+	if _, err := os.Stat(destPath); err == nil {
+		t.Error("Destination file should NOT be created when check_cmd times out")
+	}
+}
+
+// TestTimeout_PerResourceOverridesGlobal verifies that per-resource timeout
+// takes precedence over global timeout.
+func TestTimeout_PerResourceOverridesGlobal(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("precedence.conf")
+	markerPath := filepath.Join(env.DestDir, "cmd-completed")
+
+	// Write template
+	env.WriteTemplate("precedence.tmpl", `key: {{ getv "/key" }}
+`)
+
+	// Write config with per-resource timeout of 5 seconds
+	// The command sleeps for 2 seconds, so it should succeed with per-resource timeout
+	// but would fail with global 1s timeout
+	env.WriteConfig("precedence.toml", fmt.Sprintf(`[template]
+src = "precedence.tmpl"
+dest = "%s"
+check_cmd = "/bin/sh -c 'sleep 2 && echo done > %s'"
+check_cmd_timeout = "5s"
+keys = ["/key"]
+`, destPath, markerPath))
+
+	// Run confd with global check-cmd-timeout of 1 second
+	// Per-resource 5s timeout should override and allow the 2s command to complete
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir,
+		"--log-level", "error", "--check-cmd-timeout", "1s")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	exitCode, err := confd.Wait()
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+
+	// Should succeed because per-resource timeout (5s) allows the 2s command to complete
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0 (per-resource timeout should override global), got %d", exitCode)
+	}
+
+	// Destination file should be created
+	if _, err := os.Stat(destPath); os.IsNotExist(err) {
+		t.Error("Destination file should be created when check_cmd succeeds")
+	}
+
+	// Marker should exist (proves command completed)
+	content, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Error("Command marker should exist (proves command completed within per-resource timeout)")
+	} else if strings.TrimSpace(string(content)) != "done" {
+		t.Errorf("Marker has unexpected content: %q", string(content))
+	}
+}
+
+// TestTimeout_CheckCmd_ZeroMeansNoTimeout verifies that a timeout of 0
+// means no timeout is applied.
+func TestTimeout_CheckCmd_ZeroMeansNoTimeout(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	destPath := env.DestPath("no-timeout.conf")
+	markerPath := filepath.Join(env.DestDir, "no-timeout-marker")
+
+	// Write template
+	env.WriteTemplate("no-timeout.tmpl", `key: {{ getv "/key" }}
+`)
+
+	// Write config with a quick command (no real timeout test, just verify 0 works)
+	env.WriteConfig("no-timeout.toml", fmt.Sprintf(`[template]
+src = "no-timeout.tmpl"
+dest = "%s"
+check_cmd = "/bin/sh -c 'sleep 1 && echo done > %s'"
+check_cmd_timeout = "0s"
+keys = ["/key"]
+`, destPath, markerPath))
+
+	// Run confd with global timeout of 0 (no timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("KEY", "test-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir,
+		"--log-level", "error", "--check-cmd-timeout", "0s")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	exitCode, err := confd.Wait()
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+
+	// Should succeed (no timeout means command can take as long as needed)
+	if exitCode != 0 {
+		t.Errorf("Expected exit code 0 with no timeout, got %d", exitCode)
+	}
+
+	// Destination file should be created
+	if _, err := os.Stat(destPath); os.IsNotExist(err) {
+		t.Error("Destination file should be created")
+	}
+
+	// Marker should exist
+	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
+		t.Error("Marker should exist (proves command completed)")
+	}
+}
+
+// TestTimeout_MultipleTemplates_IndependentTimeouts verifies that each template
+// can have its own timeout settings.
+func TestTimeout_MultipleTemplates_IndependentTimeouts(t *testing.T) {
+	t.Parallel()
+
+	env := operations.NewTestEnv(t)
+	fastDestPath := env.DestPath("fast.conf")
+	slowDestPath := env.DestPath("slow.conf")
+	fastMarkerPath := filepath.Join(env.DestDir, "fast-marker")
+	slowMarkerPath := filepath.Join(env.DestDir, "slow-marker")
+
+	// Write templates
+	env.WriteTemplate("fast.tmpl", `fast: {{ getv "/fast" }}
+`)
+	env.WriteTemplate("slow.tmpl", `slow: {{ getv "/slow" }}
+`)
+
+	// Fast template with short timeout - command completes quickly
+	env.WriteConfig("a-fast.toml", fmt.Sprintf(`[template]
+src = "fast.tmpl"
+dest = "%s"
+check_cmd = "/bin/sh -c 'echo fast > %s'"
+check_cmd_timeout = "5s"
+keys = ["/fast"]
+`, fastDestPath, fastMarkerPath))
+
+	// Slow template with short timeout - command times out
+	env.WriteConfig("b-slow.toml", fmt.Sprintf(`[template]
+src = "slow.tmpl"
+dest = "%s"
+check_cmd = "/bin/sh -c 'sleep 10 && echo slow > %s'"
+check_cmd_timeout = "1s"
+keys = ["/slow"]
+`, slowDestPath, slowMarkerPath))
+
+	// Run confd with best-effort mode to process both templates
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	confd := operations.NewConfdBinary(t)
+	confd.SetEnv("FAST", "fast-value")
+	confd.SetEnv("SLOW", "slow-value")
+	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir,
+		"--log-level", "error", "--failure-mode", "best-effort")
+	if err != nil {
+		t.Fatalf("Failed to start confd: %v", err)
+	}
+
+	start := time.Now()
+	_, err = confd.Wait()
+	duration := time.Since(start)
+	if err != nil {
+		t.Fatalf("Error waiting for confd: %v", err)
+	}
+
+	// Total time should be around 1-2 seconds (slow template times out after 1s)
+	// Not 10+ seconds (which would indicate timeout wasn't enforced)
+	if duration > 5*time.Second {
+		t.Errorf("Independent timeouts not working correctly. Expected ~1-2s, took %v", duration)
+	}
+
+	// Fast template should succeed
+	if _, err := os.Stat(fastDestPath); os.IsNotExist(err) {
+		t.Error("Fast template should be created")
+	}
+	if _, err := os.Stat(fastMarkerPath); os.IsNotExist(err) {
+		t.Error("Fast marker should exist")
+	}
+
+	// Slow template should NOT be created (check_cmd timed out)
+	if _, err := os.Stat(slowDestPath); err == nil {
+		t.Error("Slow template should NOT be created (check_cmd timed out)")
+	}
+	// Slow marker should NOT exist (command was killed before completion)
+	if _, err := os.Stat(slowMarkerPath); err == nil {
+		t.Error("Slow marker should NOT exist (command was killed)")
+	}
+}


### PR DESCRIPTION
## Summary

Sprint 4 implementation of the E2E test plan, adding tests for advanced scenarios:

- **Per-Resource Backend Tests** (3 tests): Verify template-level backend override, mixed backends in single run, and precedence rules
- **Timeout Tests** (6 tests): Verify check_cmd/reload_cmd timeout enforcement, global vs per-resource timeout precedence
- **SIGHUP Reload Tests** (5 tests): Verify dynamic template addition, modification, removal, and config reload via SIGHUP

### New Files
- `test/e2e/features/per_resource_backend_test.go` - Per-resource backend override tests
- `test/e2e/resilience/doc.go` - New resilience package
- `test/e2e/resilience/timeout_test.go` - Command timeout tests
- `test/e2e/operations/reload_test.go` - SIGHUP configuration reload tests

### Test Coverage Added

| Test File | Tests |
|-----------|-------|
| `per_resource_backend_test.go` | OverrideGlobal, MixedBackends, Precedence |
| `timeout_test.go` | CheckCmd_EnforcesTimeout, ReloadCmd_EnforcesTimeout, CheckCmd_GlobalDefault, PerResourceOverridesGlobal, CheckCmd_ZeroMeansNoTimeout, MultipleTemplates_IndependentTimeouts |
| `reload_test.go` | AddNewTemplate, UpdatedTemplateReprocessed, RemovedTemplateStopsProcessing, ModifiedConfigReprocessed, MultipleSIGHUPs |

## Test plan
- [x] All 14 new tests pass locally
- [x] All existing E2E tests still pass
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)