### PR TITLE
fix: file backend wildcard keys filtered out (#489)

### DIFF
--- a/pkg/backends/file/client.go
+++ b/pkg/backends/file/client.go
@@ -66,11 +66,22 @@ func readFile(path string, vars map[string]string) error {
 	return nil
 }
 
+// normalizePrefix strips trailing wildcard patterns from a key prefix.
+// This allows keys like "/myapp/servers/*" to match paths like "/myapp/servers/0/host".
+func normalizePrefix(prefix string) string {
+	// Strip trailing "/*" (documented wildcard syntax)
+	prefix = strings.TrimSuffix(prefix, "/*")
+	// Also handle trailing "/" for consistency
+	prefix = strings.TrimSuffix(prefix, "/")
+	return prefix
+}
+
 // matchesAnyPrefix returns true if path has any of the given prefixes.
 // Returns false if prefixes is empty.
 func matchesAnyPrefix(path string, prefixes []string) bool {
 	for _, prefix := range prefixes {
-		if strings.HasPrefix(path, prefix) {
+		normalized := normalizePrefix(prefix)
+		if strings.HasPrefix(path, normalized) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix file backend's `matchesAnyPrefix` function filtering out results when configured keys include wildcard patterns like `/myapp/servers/*`
- Add `normalizePrefix` helper to strip trailing `/*` and `/` from key prefixes before comparison
- Add comprehensive unit tests for wildcard key handling

## Problem

The `matchesAnyPrefix` function compared paths against raw prefixes containing wildcard patterns:

```go
strings.HasPrefix("/servers/0/host", "/servers/*")  // false - literal comparison
```

This caused valid data to be incorrectly filtered out when using documented wildcard syntax.

## Solution

Normalize prefixes by stripping trailing `/*` and `/` before comparison:

```go
"/servers/*" → "/servers"
strings.HasPrefix("/servers/0/host", "/servers")  // true
```

This follows the same pattern used by the Redis backend for wildcard handling.

## Test plan

- [x] Added `TestNormalizePrefix` unit tests
- [x] Extended `TestMatchesAnyPrefix` with wildcard test cases
- [x] Added `TestGetValues_WildcardKeys` integration test
- [x] All existing tests pass (`go test ./...`)
- [x] File backend integration test passes

🤖 Generated with [Claude Code](https://claude.ai/code)