### PR TITLE
fix(config): return error for invalid duration values in confd.toml

### DIFF
--- a/cmd/confd/config.go
+++ b/cmd/confd/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -134,10 +135,12 @@ func loadConfigFile(cli *CLI, backendCfg *backends.Config) error {
 	}
 	// Stat cache TTL
 	if tomlCfg.StatCacheTTL != "" {
-		if d, err := time.ParseDuration(tomlCfg.StatCacheTTL); err == nil {
-			if cli.StatCacheTTL == DefaultStatCacheTTL {
-				cli.StatCacheTTL = d
-			}
+		d, err := time.ParseDuration(tomlCfg.StatCacheTTL)
+		if err != nil {
+			return fmt.Errorf("invalid stat_cache_ttl %q: %w (use Go duration format, e.g., \"1m\", \"5m\")", tomlCfg.StatCacheTTL, err)
+		}
+		if cli.StatCacheTTL == DefaultStatCacheTTL {
+			cli.StatCacheTTL = d
 		}
 	}
 	if cli.SRVDomain == "" && tomlCfg.SRVDomain != "" {
@@ -223,24 +226,30 @@ func loadConfigFile(cli *CLI, backendCfg *backends.Config) error {
 
 	// Connection timeout settings (apply to CLI if default, then to backend config)
 	if tomlCfg.DialTimeout != "" {
-		if d, err := time.ParseDuration(tomlCfg.DialTimeout); err == nil {
-			if cli.DialTimeout == DefaultDialTimeout {
-				cli.DialTimeout = d
-			}
+		d, err := time.ParseDuration(tomlCfg.DialTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid dial_timeout %q: %w (use Go duration format, e.g., \"5s\", \"30s\")", tomlCfg.DialTimeout, err)
+		}
+		if cli.DialTimeout == DefaultDialTimeout {
+			cli.DialTimeout = d
 		}
 	}
 	if tomlCfg.ReadTimeout != "" {
-		if d, err := time.ParseDuration(tomlCfg.ReadTimeout); err == nil {
-			if cli.ReadTimeout == DefaultReadTimeout {
-				cli.ReadTimeout = d
-			}
+		d, err := time.ParseDuration(tomlCfg.ReadTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid read_timeout %q: %w (use Go duration format, e.g., \"1s\", \"5s\")", tomlCfg.ReadTimeout, err)
+		}
+		if cli.ReadTimeout == DefaultReadTimeout {
+			cli.ReadTimeout = d
 		}
 	}
 	if tomlCfg.WriteTimeout != "" {
-		if d, err := time.ParseDuration(tomlCfg.WriteTimeout); err == nil {
-			if cli.WriteTimeout == DefaultWriteTimeout {
-				cli.WriteTimeout = d
-			}
+		d, err := time.ParseDuration(tomlCfg.WriteTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid write_timeout %q: %w (use Go duration format, e.g., \"1s\", \"5s\")", tomlCfg.WriteTimeout, err)
+		}
+		if cli.WriteTimeout == DefaultWriteTimeout {
+			cli.WriteTimeout = d
 		}
 	}
 
@@ -249,35 +258,43 @@ func loadConfigFile(cli *CLI, backendCfg *backends.Config) error {
 		cli.RetryMaxAttempts = tomlCfg.RetryMaxAttempts
 	}
 	if tomlCfg.RetryBaseDelay != "" {
-		if d, err := time.ParseDuration(tomlCfg.RetryBaseDelay); err == nil {
-			if cli.RetryBaseDelay == DefaultRetryBaseDelay {
-				cli.RetryBaseDelay = d
-			}
+		d, err := time.ParseDuration(tomlCfg.RetryBaseDelay)
+		if err != nil {
+			return fmt.Errorf("invalid retry_base_delay %q: %w (use Go duration format, e.g., \"100ms\", \"1s\")", tomlCfg.RetryBaseDelay, err)
+		}
+		if cli.RetryBaseDelay == DefaultRetryBaseDelay {
+			cli.RetryBaseDelay = d
 		}
 	}
 	if tomlCfg.RetryMaxDelay != "" {
-		if d, err := time.ParseDuration(tomlCfg.RetryMaxDelay); err == nil {
-			if cli.RetryMaxDelay == DefaultRetryMaxDelay {
-				cli.RetryMaxDelay = d
-			}
+		d, err := time.ParseDuration(tomlCfg.RetryMaxDelay)
+		if err != nil {
+			return fmt.Errorf("invalid retry_max_delay %q: %w (use Go duration format, e.g., \"5s\", \"30s\")", tomlCfg.RetryMaxDelay, err)
+		}
+		if cli.RetryMaxDelay == DefaultRetryMaxDelay {
+			cli.RetryMaxDelay = d
 		}
 	}
 
 	// Watch mode timeouts
 	if tomlCfg.WatchErrorBackoff != "" {
-		if d, err := time.ParseDuration(tomlCfg.WatchErrorBackoff); err == nil {
-			if cli.WatchErrorBackoff == DefaultWatchErrorBackoff {
-				cli.WatchErrorBackoff = d
-			}
+		d, err := time.ParseDuration(tomlCfg.WatchErrorBackoff)
+		if err != nil {
+			return fmt.Errorf("invalid watch_error_backoff %q: %w (use Go duration format, e.g., \"2s\", \"5s\")", tomlCfg.WatchErrorBackoff, err)
+		}
+		if cli.WatchErrorBackoff == DefaultWatchErrorBackoff {
+			cli.WatchErrorBackoff = d
 		}
 	}
 
 	// Preflight timeout
 	if tomlCfg.PreflightTimeout != "" {
-		if d, err := time.ParseDuration(tomlCfg.PreflightTimeout); err == nil {
-			if cli.PreflightTimeout == DefaultPreflightTimeout {
-				cli.PreflightTimeout = d
-			}
+		d, err := time.ParseDuration(tomlCfg.PreflightTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid preflight_timeout %q: %w (use Go duration format, e.g., \"10s\", \"30s\")", tomlCfg.PreflightTimeout, err)
+		}
+		if cli.PreflightTimeout == DefaultPreflightTimeout {
+			cli.PreflightTimeout = d
 		}
 	}
 

--- a/cmd/confd/config_test.go
+++ b/cmd/confd/config_test.go
@@ -1,29 +1,222 @@
 package main
 
-// This test needs to be updated for a "nil" default backend
-//
-// func TestInitConfigDefaultConfig(t *testing.T) {
-// 	log.SetLevel("warn")
-// 	want := Config{
-// 		BackendsConfig: BackendsConfig{
-// 			Backend:      "etcd",
-// 			BackendNodes: []string{"http://127.0.0.1:2379"},
-// 			Scheme:       "http",
-// 			Filter:       "*",
-// 		},
-// 		TemplateConfig: TemplateConfig{
-// 			ConfDir:     "/etc/confd",
-// 			ConfigDir:   "/etc/confd/conf.d",
-// 			TemplateDir: "/etc/confd/templates",
-// 			Noop:        false,
-// 		},
-// 		ConfigFile: "/etc/confd/confd.toml",
-// 		Interval:   600,
-// 	}
-// 	if err := initConfig(); err != nil {
-// 		t.Errorf(err.Error())
-// 	}
-// 	if !reflect.DeepEqual(want, config) {
-// 		t.Errorf("initConfig() = %v, want %v", config, want)
-// 	}
-// }
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/abtreece/confd/pkg/backends"
+)
+
+func TestLoadConfigFile_InvalidDurations(t *testing.T) {
+	tests := []struct {
+		name        string
+		configTOML  string
+		wantErrMsg  string
+		wantHint    string
+	}{
+		{
+			name: "invalid stat_cache_ttl",
+			configTOML: `
+stat_cache_ttl = "5seconds"
+`,
+			wantErrMsg: "invalid stat_cache_ttl",
+			wantHint:   `"1m", "5m"`,
+		},
+		{
+			name: "invalid dial_timeout",
+			configTOML: `
+dial_timeout = "5seconds"
+`,
+			wantErrMsg: "invalid dial_timeout",
+			wantHint:   `"5s", "30s"`,
+		},
+		{
+			name: "invalid read_timeout",
+			configTOML: `
+read_timeout = "1second"
+`,
+			wantErrMsg: "invalid read_timeout",
+			wantHint:   `"1s", "5s"`,
+		},
+		{
+			name: "invalid write_timeout",
+			configTOML: `
+write_timeout = "invalid"
+`,
+			wantErrMsg: "invalid write_timeout",
+			wantHint:   `"1s", "5s"`,
+		},
+		{
+			name: "invalid retry_base_delay",
+			configTOML: `
+retry_base_delay = "100milliseconds"
+`,
+			wantErrMsg: "invalid retry_base_delay",
+			wantHint:   `"100ms", "1s"`,
+		},
+		{
+			name: "invalid retry_max_delay",
+			configTOML: `
+retry_max_delay = "5secs"
+`,
+			wantErrMsg: "invalid retry_max_delay",
+			wantHint:   `"5s", "30s"`,
+		},
+		{
+			name: "invalid watch_error_backoff",
+			configTOML: `
+watch_error_backoff = "2sec"
+`,
+			wantErrMsg: "invalid watch_error_backoff",
+			wantHint:   `"2s", "5s"`,
+		},
+		{
+			name: "invalid preflight_timeout",
+			configTOML: `
+preflight_timeout = "10sec"
+`,
+			wantErrMsg: "invalid preflight_timeout",
+			wantHint:   `"10s", "30s"`,
+		},
+		{
+			name: "numeric without unit",
+			configTOML: `
+dial_timeout = "5"
+`,
+			wantErrMsg: "invalid dial_timeout",
+			wantHint:   `"5s", "30s"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp config file
+			tmpDir := t.TempDir()
+			configFile := filepath.Join(tmpDir, "confd.toml")
+			if err := os.WriteFile(configFile, []byte(tt.configTOML), 0644); err != nil {
+				t.Fatalf("failed to write config file: %v", err)
+			}
+
+			// Create CLI with defaults
+			cli := &CLI{
+				ConfigFile:        configFile,
+				StatCacheTTL:      DefaultStatCacheTTL,
+				DialTimeout:       DefaultDialTimeout,
+				ReadTimeout:       DefaultReadTimeout,
+				WriteTimeout:      DefaultWriteTimeout,
+				RetryBaseDelay:    DefaultRetryBaseDelay,
+				RetryMaxDelay:     DefaultRetryMaxDelay,
+				WatchErrorBackoff: DefaultWatchErrorBackoff,
+				PreflightTimeout:  DefaultPreflightTimeout,
+				RetryMaxAttempts:  DefaultRetryMaxAttempts,
+			}
+
+			backendCfg := &backends.Config{}
+
+			err := loadConfigFile(cli, backendCfg)
+
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tt.name)
+			}
+
+			errStr := err.Error()
+
+			// Check error message contains field name
+			if !strings.Contains(errStr, tt.wantErrMsg) {
+				t.Errorf("expected error to contain %q, got %q", tt.wantErrMsg, errStr)
+			}
+
+			// Check error includes helpful hint
+			if !strings.Contains(errStr, tt.wantHint) {
+				t.Errorf("expected error to contain hint %q, got %q", tt.wantHint, errStr)
+			}
+
+			// Check error includes the invalid value
+			if !strings.Contains(errStr, "invalid") {
+				t.Errorf("expected error to contain 'invalid', got %q", errStr)
+			}
+		})
+	}
+}
+
+func TestLoadConfigFile_ValidDurations(t *testing.T) {
+	configTOML := `
+stat_cache_ttl = "2m"
+dial_timeout = "10s"
+read_timeout = "3s"
+write_timeout = "3s"
+retry_base_delay = "200ms"
+retry_max_delay = "10s"
+watch_error_backoff = "5s"
+preflight_timeout = "20s"
+`
+
+	// Create temp config file
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "confd.toml")
+	if err := os.WriteFile(configFile, []byte(configTOML), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create CLI with defaults
+	cli := &CLI{
+		ConfigFile:        configFile,
+		StatCacheTTL:      DefaultStatCacheTTL,
+		DialTimeout:       DefaultDialTimeout,
+		ReadTimeout:       DefaultReadTimeout,
+		WriteTimeout:      DefaultWriteTimeout,
+		RetryBaseDelay:    DefaultRetryBaseDelay,
+		RetryMaxDelay:     DefaultRetryMaxDelay,
+		WatchErrorBackoff: DefaultWatchErrorBackoff,
+		PreflightTimeout:  DefaultPreflightTimeout,
+		RetryMaxAttempts:  DefaultRetryMaxAttempts,
+	}
+
+	backendCfg := &backends.Config{}
+
+	err := loadConfigFile(cli, backendCfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify values were applied
+	if cli.StatCacheTTL.String() != "2m0s" {
+		t.Errorf("StatCacheTTL = %v, want 2m0s", cli.StatCacheTTL)
+	}
+	if cli.DialTimeout.String() != "10s" {
+		t.Errorf("DialTimeout = %v, want 10s", cli.DialTimeout)
+	}
+	if cli.ReadTimeout.String() != "3s" {
+		t.Errorf("ReadTimeout = %v, want 3s", cli.ReadTimeout)
+	}
+	if cli.WriteTimeout.String() != "3s" {
+		t.Errorf("WriteTimeout = %v, want 3s", cli.WriteTimeout)
+	}
+	if cli.RetryBaseDelay.String() != "200ms" {
+		t.Errorf("RetryBaseDelay = %v, want 200ms", cli.RetryBaseDelay)
+	}
+	if cli.RetryMaxDelay.String() != "10s" {
+		t.Errorf("RetryMaxDelay = %v, want 10s", cli.RetryMaxDelay)
+	}
+	if cli.WatchErrorBackoff.String() != "5s" {
+		t.Errorf("WatchErrorBackoff = %v, want 5s", cli.WatchErrorBackoff)
+	}
+	if cli.PreflightTimeout.String() != "20s" {
+		t.Errorf("PreflightTimeout = %v, want 20s", cli.PreflightTimeout)
+	}
+}
+
+func TestLoadConfigFile_MissingFile(t *testing.T) {
+	cli := &CLI{
+		ConfigFile: "/nonexistent/path/confd.toml",
+	}
+	backendCfg := &backends.Config{}
+
+	// Should not error on missing file (just skip)
+	err := loadConfigFile(cli, backendCfg)
+	if err != nil {
+		t.Fatalf("unexpected error for missing config file: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Invalid duration values in confd.toml (e.g., `dial_timeout = "5seconds"`) are now detected and reported with clear error messages instead of being silently ignored
- All 8 duration fields now return errors containing the field name, invalid value, underlying error, and example valid formats
- Added comprehensive unit tests for invalid duration detection

**Before:**
```
# dial_timeout = "5seconds" silently ignored, default used
```

**After:**
```
error: invalid dial_timeout "5seconds": time: unknown unit "seconds" in duration "5seconds" (use Go duration format, e.g., "5s", "30s")
```

## Test plan

- [x] `make build` succeeds
- [x] `go test ./cmd/confd/...` passes (34 tests including 9 new invalid duration tests)
- [x] Manual test confirms clear error message for invalid duration

Fixes #502