### PR TITLE
fix(template): reduce backend fetch log verbosity

### DIFF
--- a/pkg/template/backend_fetcher.go
+++ b/pkg/template/backend_fetcher.go
@@ -92,7 +92,7 @@ func (b *backendFetcher) fetchValues() error {
 	}
 	updateDuration := time.Since(updateStart)
 
-	logger.InfoContext(ctx, "Backend fetch and store update completed",
+	logger.DebugContext(ctx, "Backend fetch and store update completed",
 		"total_duration_ms", time.Since(start).Milliseconds(),
 		"fetch_duration_ms", fetchDuration.Milliseconds(),
 		"update_duration_ms", updateDuration.Milliseconds(),


### PR DESCRIPTION
## Summary
- Change backend fetch completion log from Info to Debug level
- Reduces log noise in watch mode and short polling intervals
- Preserves diagnostic information when debug-level logging is enabled

Fixes #503

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Build succeeds (`make build`)
- [ ] Verify log appears at Debug level only when `--log-level debug` is set