### PR TITLE
fix(imds): close response body in HealthCheck and New

### DIFF
--- a/pkg/backends/imds/client.go
+++ b/pkg/backends/imds/client.go
@@ -110,6 +110,12 @@ func New(cacheTTL, dialTimeout time.Duration) (*Client, error) {
 
 	client := imds.NewFromConfig(cfg, opts...)
 
+	return newWithClient(ctx, client, cacheTTL)
+}
+
+// newWithClient creates a new IMDS Client with the provided imdsAPI implementation.
+// This is separated from New() to allow testing with mock clients.
+func newWithClient(ctx context.Context, client imdsAPI, cacheTTL time.Duration) (*Client, error) {
 	// Validate IMDS availability
 	validationOutput, err := client.GetMetadata(ctx, &imds.GetMetadataInput{
 		Path: "",


### PR DESCRIPTION
## Summary

- Fixes HTTP response body leak in IMDS `HealthCheck` method
- Fixes HTTP response body leak in IMDS `New` (client creation) validation check
- Adds tests to verify response bodies are properly closed

## Details

Previously, `GetMetadata` response bodies were not closed in two places:
1. `New()` - validation check during client creation (line 114)
2. `HealthCheck()` - basic health check method (line 335)

This is inconsistent with other methods in the same file (`HealthCheckDetailed`, `getMetadata`) which properly close response bodies. The leak could cause HTTP connection and file descriptor exhaustion over time, especially when health checks run frequently.

### Changes

**`pkg/backends/imds/client.go`**:
- Added `output.Content.Close()` call in `New()` after validation check
- Added `output.Content.Close()` call in `HealthCheck()` after successful check

**`pkg/backends/imds/client_test.go`**:
- Added `trackingReadCloser` helper to track Close() calls
- Added `mockResponseWithCloseTracking()` helper for creating trackable mock responses
- Added `TestHealthCheck_ClosesResponseBody` test
- Added `TestHealthCheckDetailed_ClosesResponseBody` test

## Test plan

- [x] All existing IMDS unit tests pass
- [x] New response body close verification tests pass
- [x] Full test suite passes

Fixes #508