### PR TITLE
docs: use version placeholders in installation guidance

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,14 +20,15 @@ docker pull ghcr.io/abtreece/confd:latest
 ```
 
 ## Image Tags
+Replace `vX.Y.Z` in the examples below with the latest release tag.
 
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release (not updated for RCs) |
-| `v0.40.0` | Specific version |
-| `v0.40.0-rc.1` | Release candidate |
-| `v0.40.0-amd64` | Architecture-specific (amd64) |
-| `v0.40.0-arm64` | Architecture-specific (arm64) |
+| `vX.Y.Z` | Specific version |
+| `vX.Y.Z-rc.N` | Release candidate |
+| `vX.Y.Z-amd64` | Architecture-specific (amd64) |
+| `vX.Y.Z-arm64` | Architecture-specific (arm64) |
 
 ## Image Details
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,15 +3,16 @@
 ### Binary Download
 
 confd ships binaries for OS X, Linux, and Windows for both amd64 and arm64 architectures. You can download the latest release from [GitHub](https://github.com/abtreece/confd/releases).
+Replace `vX.Y.Z` in the examples below with the latest release tag.
 
 #### OS X
 
 ```bash
 # For Intel Macs (amd64)
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-darwin-amd64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/vX.Y.Z/confd-vX.Y.Z-darwin-amd64.tar.gz | tar -xz -C /usr/local/bin/
 
 # For Apple Silicon (arm64)
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-darwin-arm64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/vX.Y.Z/confd-vX.Y.Z-darwin-arm64.tar.gz | tar -xz -C /usr/local/bin/
 ```
 
 #### Linux
@@ -19,16 +20,16 @@ curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40
 Download and extract the binary:
 ```bash
 # For amd64
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-amd64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/vX.Y.Z/confd-vX.Y.Z-linux-amd64.tar.gz | tar -xz -C /usr/local/bin/
 
 # For arm64
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/vX.Y.Z/confd-vX.Y.Z-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/
 ```
 
 Or manually:
 ```bash
-wget https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-amd64.tar.gz
-tar -xzf confd-v0.40.0-linux-amd64.tar.gz
+wget https://github.com/abtreece/confd/releases/download/vX.Y.Z/confd-vX.Y.Z-linux-amd64.tar.gz
+tar -xzf confd-vX.Y.Z-linux-amd64.tar.gz
 mv confd /usr/local/bin/
 ```
 
@@ -58,8 +59,8 @@ docker run --rm \
 
 Available image tags:
 - `latest` - Latest stable release
-- `v0.40.0` - Specific version
-- `v0.40.0-amd64`, `v0.40.0-arm64` - Architecture-specific images
+- `vX.Y.Z` - Specific version
+- `vX.Y.Z-amd64`, `vX.Y.Z-arm64` - Architecture-specific images
 
 See [Docker documentation](docker.md) for complete usage examples including Docker Compose and Kubernetes.
 
@@ -68,7 +69,7 @@ See [Docker documentation](docker.md) for complete usage examples including Dock
 To install confd in your own Docker image:
 
 ```dockerfile
-ARG CONFD_VERSION=0.40.0
+ARG CONFD_VERSION=X.Y.Z
 RUN CONFD_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && curl -SL "https://github.com/abtreece/confd/releases/download/v${CONFD_VERSION}/confd-v${CONFD_VERSION}-linux-${CONFD_ARCH}.tar.gz" | tar -xz -C /usr/local/bin/ \
     && confd --version


### PR DESCRIPTION
## Summary\n- replace hardcoded version tags with vX.Y.Z placeholders in installation and Docker docs\n- add notes to swap placeholders for the latest release tag\n\nCloses #515.