### PR TITLE
fix: inject version from git tag at build time

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     binary: confd
     env:
       - CGO_ENABLED=0
-    ldflags: -s -w -X main.GitSHA={{ .ShortCommit }}
+    ldflags: -s -w -X main.Version={{ .Version }} -X main.GitSHA={{ .ShortCommit }}
     goos:
       - darwin
       - linux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,10 +419,23 @@ See [docs/release-checklist.md](docs/release-checklist.md) for the complete rele
 
 ### Version Management
 
-The version is defined in `cmd/confd/version.go`. This file **must be updated** before tagging a new release, and the version string **must exactly match the tag** (without the `v` prefix).
+The version is automatically injected from the git tag at build time via goreleaser's ldflags. No manual version file updates are required.
 
-```go
-const Version = "0.40.0-rc.1"  // Must match tag v0.40.0-rc.1
+- **Release builds**: Version comes from git tag (e.g., tag `v0.40.0` → version `0.40.0`)
+- **Local builds**: Version comes from `git describe` (e.g., `0.40.0-rc.2-5-gabcdef-dirty`)
+- **Development**: Shows `dev` if no tags exist
+
+### Release Workflow
+
+```bash
+# 1. Update CHANGELOG with release notes
+# 2. Commit changes
+git add CHANGELOG
+git commit -m "docs: update CHANGELOG for v0.41.0"
+
+# 3. Tag and push
+git tag -a v0.41.0 -m "v0.41.0"
+git push origin main v0.41.0
 ```
 
 ### Release Candidate Workflow
@@ -430,38 +443,17 @@ const Version = "0.40.0-rc.1"  // Must match tag v0.40.0-rc.1
 For significant releases, use release candidates:
 
 ```bash
-# 1. Update version.go to "0.40.0-rc.1"
-# 2. Commit and tag
-git add cmd/confd/version.go
-git commit -m "chore: bump version to 0.40.0-rc.1"
+# RC1
 git tag -a v0.40.0-rc.1 -m "v0.40.0-rc.1"
-git push origin main v0.40.0-rc.1
+git push origin v0.40.0-rc.1
 
-# 3. If issues are found, fix them, then update version.go to "0.40.0-rc.2"
-git add cmd/confd/version.go
-git commit -m "chore: bump version to 0.40.0-rc.2"
+# If issues are found, fix them and tag RC2
 git tag -a v0.40.0-rc.2 -m "v0.40.0-rc.2"
-git push origin main v0.40.0-rc.2
+git push origin v0.40.0-rc.2
 
-# 4. When stable, update version.go to "0.40.0" and tag final release
-git add cmd/confd/version.go
-git commit -m "chore: bump version to 0.40.0"
+# When stable, tag final release
 git tag -a v0.40.0 -m "v0.40.0"
 git push origin main v0.40.0
-```
-
-### Standard Release Workflow
-
-For minor releases and patches (no RC needed):
-
-```bash
-# 1. Update version.go to match tag (e.g., "0.41.0")
-# 2. Update CHANGELOG
-# 3. Commit, tag, and push
-git add cmd/confd/version.go CHANGELOG
-git commit -m "chore: bump version to 0.41.0"
-git tag -a v0.41.0 -m "v0.41.0"
-git push origin main v0.41.0
 ```
 
 ### Goreleaser
@@ -473,8 +465,7 @@ Tags trigger GitHub Actions which run goreleaser:
 ### Checklist
 
 Before tagging any release:
-- [ ] Update `cmd/confd/version.go` to match the tag (e.g., `"0.40.0-rc.1"` for tag `v0.40.0-rc.1`)
 - [ ] Update `CHANGELOG` with release notes
 - [ ] Ensure all tests pass (`make test`)
 - [ ] Ensure build succeeds (`make build`)
-- [ ] Verify version: `./bin/confd --version` shows correct version
+- [ ] Verify version after build: `./bin/confd --version`

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: build install clean lint test integration dep release
-VERSION=`egrep -o '[0-9]+\.[0-9a-z.\-]+' cmd/confd/version.go`
-GIT_SHA=`git rev-parse --short HEAD || echo`
+VERSION=$(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "dev")
+GIT_SHA=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 build:
 	@echo "Building confd..."
 	@mkdir -p bin
-	@go build -ldflags "-X main.GitSHA=${GIT_SHA}" -o bin/confd ./cmd/confd
+	@go build -ldflags "-X main.Version=$(VERSION) -X main.GitSHA=$(GIT_SHA)" -o bin/confd ./cmd/confd
 
 install:
 	@echo "Installing confd..."

--- a/cmd/confd/version.go
+++ b/cmd/confd/version.go
@@ -1,6 +1,9 @@
 package main
 
-const Version = "0.40.0-rc.2"
-
-// We want to replace this variable at build time with "-ldflags -X main.GitSHA=xxx", where const is not supported.
-var GitSHA = ""
+// Version and GitSHA are set at build time via ldflags.
+// Example: -ldflags "-X main.Version=1.0.0 -X main.GitSHA=abc123"
+// Goreleaser automatically injects these from the git tag.
+var (
+	Version = "dev"
+	GitSHA  = ""
+)


### PR DESCRIPTION
## Summary

Goreleaser now injects the version from the git tag via ldflags, eliminating the need to manually update `version.go` before releases.

- `.goreleaser.yml`: Add `-X main.Version={{ .Version }}` to ldflags
- `version.go`: Change `const` to `var` with `"dev"` default
- `Makefile`: Use `git describe` for local builds
- `CLAUDE.md`: Simplify release process documentation

## Test plan

- [x] Verified with goreleaser snapshot build
- [x] Verified released v0.33.1 binary shows correct version
- [x] Local `make build` produces versioned binary

Fixes #521