### PR TITLE
chore: bump Go from 1.25.5 to 1.25.8

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: "1.25.8"
 
       - name: Run go test for coverage
         run: go test -vet=off ./... -race -coverprofile=coverage.out -covermode=atomic

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: "1.25.8"
 
       - name: Run E2E Tests
         run: go test -v -tags=e2e -timeout 15m ./test/e2e/...

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: "1.25.8"
 
       - name: Build and Install
         run: |
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: "1.25.8"
 
       - name: Build and Install
         run: |
@@ -173,7 +173,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: "1.25.8"
 
       - name: Build and Install
         run: |
@@ -232,7 +232,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: "1.25.8"
 
       - name: Build and Install
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.5
+golang 1.25.8

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abtreece/confd
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.5 to 1.25.8 across `go.mod`, `.tool-versions`, and all CI workflows
- Required for dependabot PR #534 (`consul/api` v1.33.4) which needs `go >= 1.25.8`

## Test plan
- [x] `make build` succeeds
- [x] `go test ./...` all pass
- [ ] CI workflows pass with Go 1.25.8