### PR TITLE
chore: prepare v0.40.0 release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters:
   enable:
     - errorlint     # Enforce error wrapping and proper use of errors

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,62 +1,3 @@
-### v0.40.0-rc.2
-
-Release candidate for v0.40.0 with Linux packaging and critical bug fixes.
-
-**New Features**:
-
-* feat(packaging): Add RPM and DEB package support via nFPM (#520)
-  - Systemd service with security hardening
-  - Environment file configuration (`/etc/default/confd` or `/etc/sysconfig/confd`)
-  - Packages for amd64, arm64, and armv7 architectures
-* feat(cli): Add comprehensive environment variable support (#516)
-
-**Bug Fixes**:
-
-* fix: Address high severity bugs - goroutine leaks, FD leaks, data races (#493, #494, #496, #497)
-* fix: File backend wildcard keys filtered out (#498)
-* fix: Preflight now uses per-resource backend for key checks (#495)
-* fix(redis): Support multiple prefixes in WatchPrefix (#510)
-* fix(imds): Close response body in HealthCheck and New (#511)
-* fix(imds): Avoid trailing slash in user-data cache key (#500)
-* fix(backends): Respect context cancellation in WatchPrefix stubs (#512)
-* fix(template): Use atomic.Bool for reloadRequested to prevent data race (#504)
-* fix(template): Reduce backend fetch log verbosity (#506)
-* fix(config): Return error for invalid duration values in confd.toml (#505)
-* fix(zookeeper): Propagate errors from recursive nodeWalk calls (#499)
-
-**Testing**:
-
-* test(template): Add integration tests for watch reconnection after backend failures (#519)
-* Complete E2E test migration to Go testcontainers framework (#464-476)
-
-**Documentation**:
-
-* docs: Add Linux package installation instructions
-* docs: Update service deployment guide with package-based setup
-
-Install via packages:
-```bash
-# Debian/Ubuntu
-curl -LO https://github.com/abtreece/confd/releases/download/v0.40.0-rc.2/confd_0.40.0-rc.2_linux_amd64.deb
-sudo dpkg -i confd_0.40.0-rc.2_linux_amd64.deb
-
-# RHEL/Fedora
-curl -LO https://github.com/abtreece/confd/releases/download/v0.40.0-rc.2/confd-0.40.0.rc.2-1.x86_64.rpm
-sudo rpm -i confd-0.40.0.rc.2-1.x86_64.rpm
-```
-
-### v0.40.0-rc.1
-
-Release candidate for v0.40.0 with Docker container support.
-
-**New in this RC**:
-
-* feat: Add official Docker images published to Docker Hub and GHCR
-* feat: Multi-architecture support (linux/amd64, linux/arm64)
-* feat: Add workflow_dispatch for manual release triggers
-
-Docker images: `abtreece/confd:v0.40.0-rc.1` or `ghcr.io/abtreece/confd:v0.40.0-rc.1`
-
 ### v0.40.0
 
 This release represents a significant evolution of confd with major architectural improvements, new features, and performance optimizations. The version jump from v0.33.0 to v0.40.0 reflects the scope of these changes.
@@ -83,6 +24,10 @@ This release represents a significant evolution of confd with major architectura
 * feat: Add per-resource backend configuration support (#359)
 * feat: Add configuration validation, template enhancements, and watch mode improvements (#360)
 * feat(redis): Implement exponential backoff for connection retries (#405)
+* feat: Add official Docker images published to Docker Hub and GHCR (#463)
+* feat: Multi-architecture Docker support (linux/amd64, linux/arm64)
+* feat(packaging): Add RPM and DEB package support via nFPM (#520)
+* feat(cli): Add comprehensive environment variable support (#516)
 
 **Performance Improvements**:
 
@@ -97,10 +42,21 @@ This release represents a significant evolution of confd with major architectura
 
 **Bug Fixes**:
 
+* fix: Address high severity bugs - goroutine leaks, FD leaks, data races (#493, #494, #496, #497)
+* fix: File backend wildcard keys filtered out (#498)
+* fix: Preflight now uses per-resource backend for key checks (#495)
+* fix: Inject version from git tag at build time (#522)
+* fix(redis): Support multiple prefixes in WatchPrefix (#510)
+* fix(imds): Close response body in HealthCheck and New (#511)
+* fix(imds): Avoid trailing slash in user-data cache key (#500)
+* fix(backends): Respect context cancellation in WatchPrefix stubs (#512)
+* fix(template): Use atomic.Bool for reloadRequested to prevent data race (#504)
+* fix(template): Reduce backend fetch log verbosity (#506)
+* fix(config): Return error for invalid duration values in confd.toml (#505)
+* fix(zookeeper): Propagate errors from recursive nodeWalk calls (#499)
 * fix: Exclude timeout fields from client cache hash (#455)
 * fix(vault): Improve flatten() function type safety (#433)
 * fix(redis): Add automatic reconnection for PubSub watch mode (#408)
-* fix: Improve code quality and fix potential issues (#380)
 
 **Refactoring**:
 
@@ -113,6 +69,8 @@ This release represents a significant evolution of confd with major architectura
 
 **Testing**:
 
+* Complete E2E test migration to Go testcontainers framework (#464-476)
+* test(template): Add integration tests for watch reconnection after backend failures (#519)
 * Comprehensive integration test suite reorganized into categorical structure (#432)
 * Test coverage improved significantly across all backends
 * Added integration tests for health, metrics, failure modes, includes, and signals (#430)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ confd provides native packages for Debian/Ubuntu (.deb) and RHEL/Fedora/CentOS (
 
 ```bash
 # Download the latest release (replace VERSION and ARCH as needed)
-VERSION=0.34.0
+VERSION=0.40.0
 ARCH=amd64  # or arm64
 
 curl -LO "https://github.com/abtreece/confd/releases/download/v${VERSION}/confd_${VERSION}_linux_${ARCH}.deb"
@@ -19,7 +19,7 @@ sudo dpkg -i "confd_${VERSION}_linux_${ARCH}.deb"
 
 ```bash
 # Download the latest release (replace VERSION and ARCH as needed)
-VERSION=0.34.0
+VERSION=0.40.0
 ARCH=x86_64  # or aarch64
 
 curl -LO "https://github.com/abtreece/confd/releases/download/v${VERSION}/confd-${VERSION}-1.${ARCH}.rpm"
@@ -79,10 +79,10 @@ confd ships binaries for OS X, Linux, and Windows for both amd64 and arm64 archi
 
 ```bash
 # For Intel Macs (amd64)
-curl -SL https://github.com/abtreece/confd/releases/download/v0.33.0/confd-v0.33.0-darwin-amd64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-darwin-amd64.tar.gz | tar -xz -C /usr/local/bin/
 
 # For Apple Silicon (arm64)
-curl -SL https://github.com/abtreece/confd/releases/download/v0.33.0/confd-v0.33.0-darwin-arm64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-darwin-arm64.tar.gz | tar -xz -C /usr/local/bin/
 ```
 
 #### Linux
@@ -90,16 +90,16 @@ curl -SL https://github.com/abtreece/confd/releases/download/v0.33.0/confd-v0.33
 Download and extract the binary:
 ```bash
 # For amd64
-curl -SL https://github.com/abtreece/confd/releases/download/v0.33.0/confd-v0.33.0-linux-amd64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-amd64.tar.gz | tar -xz -C /usr/local/bin/
 
 # For arm64
-curl -SL https://github.com/abtreece/confd/releases/download/v0.33.0/confd-v0.33.0-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/
 ```
 
 Or manually:
 ```bash
-wget https://github.com/abtreece/confd/releases/download/v0.33.0/confd-v0.33.0-linux-amd64.tar.gz
-tar -xzf confd-v0.33.0-linux-amd64.tar.gz
+wget https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-amd64.tar.gz
+tar -xzf confd-v0.40.0-linux-amd64.tar.gz
 mv confd /usr/local/bin/
 ```
 
@@ -129,8 +129,8 @@ docker run --rm \
 
 Available image tags:
 - `latest` - Latest stable release
-- `v0.33.0` - Specific version
-- `v0.33.0-amd64`, `v0.33.0-arm64` - Architecture-specific images
+- `v0.40.0` - Specific version
+- `v0.40.0-amd64`, `v0.40.0-arm64` - Architecture-specific images
 
 See [Docker documentation](docker.md) for complete usage examples including Docker Compose and Kubernetes.
 
@@ -139,7 +139,7 @@ See [Docker documentation](docker.md) for complete usage examples including Dock
 To install confd in your own Docker image:
 
 ```dockerfile
-ARG CONFD_VERSION=0.33.0
+ARG CONFD_VERSION=0.40.0
 RUN CONFD_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && curl -SL "https://github.com/abtreece/confd/releases/download/v${CONFD_VERSION}/confd-v${CONFD_VERSION}-linux-${CONFD_ARCH}.tar.gz" | tar -xz -C /usr/local/bin/ \
     && confd --version

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -120,13 +120,11 @@ type watchProcessor struct {
 
 // WatchProcessor creates a processor that watches for backend changes continuously.
 func WatchProcessor(config Config, stopChan, doneChan chan bool, errChan chan error, reloadChan <-chan struct{}) Processor {
-	var wg sync.WaitGroup
 	return &watchProcessor{
 		config:       config,
 		stopChan:     stopChan,
 		doneChan:     doneChan,
 		errChan:      errChan,
-		wg:           wg,
 		reloadChan:   reloadChan,
 		internalStop: make(chan bool),
 	}
@@ -289,7 +287,6 @@ type batchWatchProcessor struct {
 // BatchWatchProcessor creates a processor that batches changes before processing.
 // Changes from all templates are collected and processed together after the batch interval.
 func BatchWatchProcessor(config Config, stopChan, doneChan chan bool, errChan chan error, reloadChan <-chan struct{}) Processor {
-	var wg sync.WaitGroup
 	changeChan := make(chan *TemplateResource, 100)
 	return &batchWatchProcessor{
 		config:       config,
@@ -297,7 +294,6 @@ func BatchWatchProcessor(config Config, stopChan, doneChan chan bool, errChan ch
 		doneChan:     doneChan,
 		errChan:      errChan,
 		changeChan:   changeChan,
-		wg:           wg,
 		reloadChan:   reloadChan,
 		internalStop: make(chan bool),
 	}


### PR DESCRIPTION
## Summary

- **Fix WaitGroup copy bug** in `pkg/template/processor.go` — `go vet` flagged `sync.WaitGroup` being copied by value in `WatchProcessor()` and `BatchWatchProcessor()`. Removed unnecessary intermediate variable; zero value is valid.
- **Migrate golangci-lint config to v2** — added required `version: "2"` field to `.golangci.yml` for compatibility with golangci-lint v2.x.
- **Consolidate CHANGELOG for v0.40.0** — removed RC-specific sections (rc.1, rc.2), merged all features/fixes into the final v0.40.0 entry, added Docker/packaging/env-var features and version injection fix (#522).
- **Update installation docs** — replaced all v0.33.0 and v0.34.0 version references with v0.40.0 in `docs/installation.md`.

## Test plan

- [x] `go vet ./...` passes clean (was failing before)
- [x] `go test -race ./pkg/template/` passes
- [x] `golangci-lint run ./...` runs successfully (was failing before)
- [ ] CI passes