### PR TITLE
refactor: remove inFlightCmds WaitGroup — redundant with processor lifecycle

### DIFF
--- a/cmd/confd/cli.go
+++ b/cmd/confd/cli.go
@@ -555,8 +555,7 @@ func run(cli *CLI, backendCfg backends.Config) error {
 	go processor.Process()
 
 	// Create shutdown manager for graceful shutdown coordination
-	var inFlightCmds sync.WaitGroup
-	shutdownMgr := service.NewShutdownManager(cli.ShutdownTimeout, metricsServer, storeClient, &inFlightCmds)
+	shutdownMgr := service.NewShutdownManager(cli.ShutdownTimeout, metricsServer, storeClient)
 
 	// Create systemd notifier and start watchdog if enabled
 	systemdNotifier := service.NewSystemdNotifier(cli.SystemdNotify, cli.WatchdogInterval)

--- a/pkg/service/shutdown.go
+++ b/pkg/service/shutdown.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/abtreece/confd/pkg/backends"
@@ -16,23 +15,25 @@ type ShutdownManager struct {
 	timeout       time.Duration
 	metricsServer *http.Server
 	storeClient   backends.StoreClient
-	inFlightCmds  *sync.WaitGroup
 }
 
 // NewShutdownManager creates a new shutdown manager.
-func NewShutdownManager(timeout time.Duration, metricsServer *http.Server, storeClient backends.StoreClient, inFlightCmds *sync.WaitGroup) *ShutdownManager {
+func NewShutdownManager(timeout time.Duration, metricsServer *http.Server, storeClient backends.StoreClient) *ShutdownManager {
 	return &ShutdownManager{
 		timeout:       timeout,
 		metricsServer: metricsServer,
 		storeClient:   storeClient,
-		inFlightCmds:  inFlightCmds,
 	}
 }
 
-// Shutdown performs graceful shutdown in three phases:
-// 1. Wait for in-flight commands to complete (with timeout)
-// 2. Shutdown metrics server gracefully
-// 3. Close backend connections
+// Shutdown performs graceful shutdown in two phases:
+// 1. Shutdown metrics server gracefully
+// 2. Close backend connections
+//
+// In-flight check/reload commands do not need explicit tracking here: all
+// three processor types (interval, watch, batch-watch) complete any
+// in-progress process() call before closing doneChan, so by the time
+// Shutdown is called the processor has already drained.
 func (s *ShutdownManager) Shutdown(ctx context.Context) error {
 	log.Info("Starting graceful shutdown (timeout: %v)", s.timeout)
 
@@ -40,27 +41,9 @@ func (s *ShutdownManager) Shutdown(ctx context.Context) error {
 	shutdownCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
-	// Phase 1: Wait for in-flight commands with timeout
-	log.Info("Phase 1: Waiting for in-flight commands to complete")
-	cmdsDone := make(chan struct{})
-	go func() {
-		if s.inFlightCmds != nil {
-			s.inFlightCmds.Wait()
-		}
-		close(cmdsDone)
-	}()
-
-	select {
-	case <-cmdsDone:
-		log.Info("All in-flight commands completed")
-	case <-shutdownCtx.Done():
-		log.Warning("Shutdown timeout waiting for in-flight commands")
-	}
-
-	// Phase 2: Shutdown metrics server
+	// Phase 1: Shutdown metrics server
 	if s.metricsServer != nil {
-		log.Info("Phase 2: Shutting down metrics server")
-		// Give metrics server a small timeout (5 seconds or remaining time, whichever is less)
+		log.Info("Phase 1: Shutting down metrics server")
 		serverTimeout := 5 * time.Second
 		if deadline, ok := shutdownCtx.Deadline(); ok {
 			remaining := time.Until(deadline)
@@ -79,8 +62,8 @@ func (s *ShutdownManager) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// Phase 3: Close backend connections
-	log.Info("Phase 3: Closing backend connections")
+	// Phase 2: Close backend connections
+	log.Info("Phase 2: Closing backend connections")
 	if s.storeClient != nil {
 		if err := s.storeClient.Close(); err != nil {
 			log.Warning("Backend connection close error: %v", err)

--- a/pkg/service/shutdown_test.go
+++ b/pkg/service/shutdown_test.go
@@ -80,15 +80,12 @@ func TestShutdown_NilStoreClient(t *testing.T) {
 }
 
 func TestShutdown_WithMetricsServer(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	// Convert httptest.Server to http.Server for shutdown
-	httpSrv := &http.Server{Addr: srv.Listener.Addr().String()}
-	httpSrv.Handler = http.DefaultServeMux
-	// Start the server on the test listener
-	go func() { _ = httpSrv.Serve(srv.Listener) }()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+	srv.Start()
 
 	client := &mockStoreClient{}
-	mgr := NewShutdownManager(5*time.Second, httpSrv, client)
+	mgr := NewShutdownManager(5*time.Second, srv.Config, client)
 
 	if err := mgr.Shutdown(context.Background()); err != nil {
 		t.Fatalf("Shutdown returned error: %v", err)

--- a/pkg/service/shutdown_test.go
+++ b/pkg/service/shutdown_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// mockStoreClient is a minimal StoreClient for shutdown tests.
+type mockStoreClient struct {
+	closeErr error
+	closed   bool
+}
+
+func (m *mockStoreClient) GetValues(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (m *mockStoreClient) WatchPrefix(_ context.Context, _ string, _ []string, _ uint64, _ chan bool) (uint64, error) {
+	return 0, nil
+}
+
+func (m *mockStoreClient) HealthCheck(_ context.Context) error {
+	return nil
+}
+
+func (m *mockStoreClient) Close() error {
+	m.closed = true
+	return m.closeErr
+}
+
+func TestNewShutdownManager(t *testing.T) {
+	client := &mockStoreClient{}
+	mgr := NewShutdownManager(30*time.Second, nil, client)
+	if mgr == nil {
+		t.Fatal("expected non-nil ShutdownManager")
+	}
+	if mgr.timeout != 30*time.Second {
+		t.Errorf("timeout = %v, want 30s", mgr.timeout)
+	}
+	if mgr.storeClient != client {
+		t.Error("storeClient not set correctly")
+	}
+}
+
+func TestShutdown_ClosesStoreClient(t *testing.T) {
+	client := &mockStoreClient{}
+	mgr := NewShutdownManager(5*time.Second, nil, client)
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+	if !client.closed {
+		t.Error("expected storeClient.Close() to be called")
+	}
+}
+
+func TestShutdown_StoreClientCloseError(t *testing.T) {
+	closeErr := errors.New("connection reset")
+	client := &mockStoreClient{closeErr: closeErr}
+	mgr := NewShutdownManager(5*time.Second, nil, client)
+
+	err := mgr.Shutdown(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Shutdown, got nil")
+	}
+	if !errors.Is(err, closeErr) {
+		t.Errorf("error = %v, want to wrap %v", err, closeErr)
+	}
+}
+
+func TestShutdown_NilStoreClient(t *testing.T) {
+	mgr := NewShutdownManager(5*time.Second, nil, nil)
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown with nil storeClient returned error: %v", err)
+	}
+}
+
+func TestShutdown_WithMetricsServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	// Convert httptest.Server to http.Server for shutdown
+	httpSrv := &http.Server{Addr: srv.Listener.Addr().String()}
+	httpSrv.Handler = http.DefaultServeMux
+	// Start the server on the test listener
+	go func() { _ = httpSrv.Serve(srv.Listener) }()
+
+	client := &mockStoreClient{}
+	mgr := NewShutdownManager(5*time.Second, httpSrv, client)
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+	if !client.closed {
+		t.Error("expected storeClient.Close() to be called")
+	}
+}
+
+func TestShutdown_NilMetricsServer(t *testing.T) {
+	client := &mockStoreClient{}
+	mgr := NewShutdownManager(5*time.Second, nil, client)
+
+	// Should not panic with nil metrics server
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+}
+
+func TestShutdown_TimeoutPropagated(t *testing.T) {
+	// A very short timeout should still complete without panic when
+	// there is no metrics server and the store client closes quickly.
+	client := &mockStoreClient{}
+	mgr := NewShutdownManager(1*time.Millisecond, nil, client)
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Removes the unused `inFlightCmds sync.WaitGroup` from `cli.go` and `ShutdownManager`
- Collapses shutdown from three phases to two (metrics server → backend close)
- Adds `pkg/service/shutdown_test.go` with 7 test cases covering the `ShutdownManager`

Closes #558

## Why removal is correct

All three processor types complete any in-progress `process()` call before closing `doneChan`:

- **Interval processor**: `process()` runs synchronously in the loop body; `ctx.Done()`/`stopChan` are only checked after it returns
- **Watch processor**: `t.process()` runs in the `default` branch of a select; `wg.Done()` is deferred so `wg.Wait()` (which gates `doneChan`) cannot unblock until every goroutine's current `process()` finishes
- **Batch watch processor**: both `ctx.Done()` and `internalStop` cases explicitly drain pending work via `processWithResult()` before returning

By the time `<-doneChan` unblocks in `cli.go` and `Shutdown()` is called, every check/reload command has already completed. Phase 1's `inFlightCmds.Wait()` was always a no-op — nothing ever called `Add()`.

## Test plan

- [ ] `go test ./pkg/service/ -v` — all 7 new shutdown tests pass
- [ ] `go test ./... -count=1` — full suite passes