### PR TITLE
fix: propagate context through Vault and Zookeeper GetValues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* fix: Propagate context through Vault and Zookeeper GetValues — `--backend-timeout` and caller cancellation now take effect for Vault (updated vaultLogical interface to use `*WithContext` variants) and Zookeeper (goroutine+select wrappers for blocking calls) (#566)
+
 * fix: Close cached per-resource backend clients on shutdown — prevents connection/resource leaks when template resources override the global backend; lock is released before Close() to prevent deadlock (#564)
 
 * perf: Cache template resources across interval cycles — eliminates per-tick filesystem walk, TOML parse, and TemplateResource construction in intervalProcessor; resources loaded once at startup, reloaded only on SIGHUP (#553)

--- a/pkg/backends/vault/client.go
+++ b/pkg/backends/vault/client.go
@@ -22,10 +22,10 @@ import (
 // vaultLogical defines the interface for Vault logical operations.
 // This allows for mocking in tests.
 type vaultLogical interface {
-	List(path string) (*vaultapi.Secret, error)
-	Read(path string) (*vaultapi.Secret, error)
-	ReadRaw(path string) (*vaultapi.Response, error)
-	Write(path string, data map[string]interface{}) (*vaultapi.Secret, error)
+	ListWithContext(ctx context.Context, path string) (*vaultapi.Secret, error)
+	ReadWithContext(ctx context.Context, path string) (*vaultapi.Secret, error)
+	ReadRawWithContext(ctx context.Context, path string) (*vaultapi.Response, error)
+	WriteWithContext(ctx context.Context, path string, data map[string]interface{}) (*vaultapi.Secret, error)
 }
 
 // Client is a wrapper around the vault client
@@ -232,7 +232,7 @@ func (c *Client) GetValues(ctx context.Context, paths []string) (map[string]stri
 
 	var errs []error
 	for _, mount := range mounts {
-		resp, err := c.logical.ReadRaw("/sys/internal/ui/mounts/" + mount)
+		resp, err := c.logical.ReadRawWithContext(ctx, "/sys/internal/ui/mounts/"+mount)
 		if err != nil {
 			log.Warning("failed to get mount info for %s: %v", mount, err)
 			errs = append(errs, fmt.Errorf("mount %s: failed to get mount info: %w", mount, err))
@@ -265,11 +265,11 @@ func (c *Client) GetValues(ctx context.Context, paths []string) (map[string]stri
 				continue
 			}
 			var key string
-			secrets := recursiveListSecretWithLogical(c.logical, mount, key, version)
+			secrets := recursiveListSecretWithLogical(ctx, c.logical, mount, key, version)
 			switch version {
 			case "", "1":
 				for _, secretPath := range secrets {
-					secretResp, err := c.logical.Read(secretPath)
+					secretResp, err := c.logical.ReadWithContext(ctx, secretPath)
 					if err != nil {
 						log.Warning("failed to read secret %s: %v", secretPath, err)
 						errs = append(errs, fmt.Errorf("secret %s: failed to read: %w", secretPath, err))
@@ -289,7 +289,7 @@ func (c *Client) GetValues(ctx context.Context, paths []string) (map[string]stri
 				}
 			case "2":
 				for _, secretPath := range secrets {
-					secretResp, err := c.logical.Read(secretPath)
+					secretResp, err := c.logical.ReadWithContext(ctx, secretPath)
 					if err != nil {
 						log.Warning("failed to read secret %s: %v", secretPath, err)
 						errs = append(errs, fmt.Errorf("secret %s: failed to read: %w", secretPath, err))
@@ -399,9 +399,9 @@ func buildSecretPath(basePath, key, version string) string {
 }
 
 // listSecretWithLogical returns a list of secrets from Vault using the vaultLogical interface
-func listSecretWithLogical(logical vaultLogical, path string, key string, version string) (*vaultapi.Secret, error) {
+func listSecretWithLogical(ctx context.Context, logical vaultLogical, path string, key string, version string) (*vaultapi.Secret, error) {
 	listPath := buildListPath(path, key, version)
-	secret, err := logical.List(listPath)
+	secret, err := logical.ListWithContext(ctx, listPath)
 	if err != nil {
 		log.Warning("Couldn't list from the Vault: %v", err)
 	}
@@ -409,9 +409,9 @@ func listSecretWithLogical(logical vaultLogical, path string, key string, versio
 }
 
 // recursiveListSecretWithLogical returns a list of secrets paths from Vault using the vaultLogical interface
-func recursiveListSecretWithLogical(logical vaultLogical, basePath string, key string, version string) []string {
+func recursiveListSecretWithLogical(ctx context.Context, logical vaultLogical, basePath string, key string, version string) []string {
 	var results []string
-	secretList, err := listSecretWithLogical(logical, basePath, key, version)
+	secretList, err := listSecretWithLogical(ctx, logical, basePath, key, version)
 	if err != nil || secretList == nil || secretList.Data == nil {
 		return results
 	}
@@ -429,7 +429,7 @@ func recursiveListSecretWithLogical(logical vaultLogical, basePath string, key s
 		if strings.HasSuffix(secretStr, "/") {
 			// It's a directory, recurse
 			newKey := key + "/" + strings.TrimSuffix(secretStr, "/")
-			subResults := recursiveListSecretWithLogical(logical, basePath, newKey, version)
+			subResults := recursiveListSecretWithLogical(ctx, logical, basePath, newKey, version)
 			results = append(results, subResults...)
 		} else {
 			// It's a secret

--- a/pkg/backends/vault/client_test.go
+++ b/pkg/backends/vault/client_test.go
@@ -520,28 +520,28 @@ type mockVaultLogical struct {
 	writeFunc   func(path string, data map[string]interface{}) (*vaultapi.Secret, error)
 }
 
-func (m *mockVaultLogical) List(path string) (*vaultapi.Secret, error) {
+func (m *mockVaultLogical) ListWithContext(_ context.Context, path string) (*vaultapi.Secret, error) {
 	if m.listFunc != nil {
 		return m.listFunc(path)
 	}
 	return nil, nil
 }
 
-func (m *mockVaultLogical) Read(path string) (*vaultapi.Secret, error) {
+func (m *mockVaultLogical) ReadWithContext(_ context.Context, path string) (*vaultapi.Secret, error) {
 	if m.readFunc != nil {
 		return m.readFunc(path)
 	}
 	return nil, nil
 }
 
-func (m *mockVaultLogical) ReadRaw(path string) (*vaultapi.Response, error) {
+func (m *mockVaultLogical) ReadRawWithContext(_ context.Context, path string) (*vaultapi.Response, error) {
 	if m.readRawFunc != nil {
 		return m.readRawFunc(path)
 	}
 	return nil, nil
 }
 
-func (m *mockVaultLogical) Write(path string, data map[string]interface{}) (*vaultapi.Secret, error) {
+func (m *mockVaultLogical) WriteWithContext(_ context.Context, path string, data map[string]interface{}) (*vaultapi.Secret, error) {
 	if m.writeFunc != nil {
 		return m.writeFunc(path, data)
 	}
@@ -562,7 +562,7 @@ func TestListSecretWithLogical_Version1(t *testing.T) {
 		},
 	}
 
-	result, err := listSecretWithLogical(mock, "/secret", "/mykey", "1")
+	result, err := listSecretWithLogical(context.Background(), mock, "/secret", "/mykey", "1")
 	if err != nil {
 		t.Fatalf("listSecretWithLogical() unexpected error: %v", err)
 	}
@@ -590,7 +590,7 @@ func TestListSecretWithLogical_Version2(t *testing.T) {
 		},
 	}
 
-	result, err := listSecretWithLogical(mock, "/secret", "/mykey", "2")
+	result, err := listSecretWithLogical(context.Background(), mock, "/secret", "/mykey", "2")
 	if err != nil {
 		t.Fatalf("listSecretWithLogical() unexpected error: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestListSecretWithLogical_EmptyVersion(t *testing.T) {
 	}
 
 	// Empty version should behave like version 1
-	result, err := listSecretWithLogical(mock, "/secret", "/key", "")
+	result, err := listSecretWithLogical(context.Background(), mock, "/secret", "/key", "")
 	if err != nil {
 		t.Fatalf("listSecretWithLogical() unexpected error: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestListSecretWithLogical_EmptyVersion(t *testing.T) {
 func TestListSecretWithLogical_UnsupportedVersion(t *testing.T) {
 	mock := &mockVaultLogical{}
 
-	result, err := listSecretWithLogical(mock, "/secret", "/key", "unsupported")
+	result, err := listSecretWithLogical(context.Background(), mock, "/secret", "/key", "unsupported")
 	if err != nil {
 		t.Errorf("listSecretWithLogical() unexpected error: %v", err)
 	}
@@ -645,7 +645,7 @@ func TestListSecretWithLogical_Error(t *testing.T) {
 		},
 	}
 
-	_, err := listSecretWithLogical(mock, "/secret", "/key", "1")
+	_, err := listSecretWithLogical(context.Background(), mock, "/secret", "/key", "1")
 	if err != expectedErr {
 		t.Errorf("listSecretWithLogical() error = %v, want %v", err, expectedErr)
 	}
@@ -662,7 +662,7 @@ func TestRecursiveListSecretWithLogical_SingleSecret_V1(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "1")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "1")
 	if len(result) == 0 {
 		t.Error("recursiveListSecretWithLogical() returned empty result")
 	}
@@ -691,7 +691,7 @@ func TestRecursiveListSecretWithLogical_SingleSecret_V2(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "2")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "2")
 	if len(result) == 0 {
 		t.Error("recursiveListSecretWithLogical() returned empty result")
 	}
@@ -731,7 +731,7 @@ func TestRecursiveListSecretWithLogical_WithSubdirectory_V1(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "1")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "1")
 	if len(result) < 2 {
 		t.Errorf("recursiveListSecretWithLogical() returned %d paths, want at least 2", len(result))
 	}
@@ -744,7 +744,7 @@ func TestRecursiveListSecretWithLogical_NilSecretList_V1(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "1")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "1")
 	// When secretList is nil, an empty slice should be returned
 	if len(result) != 0 {
 		t.Errorf("recursiveListSecretWithLogical() expected empty slice when list returns nil, got %v", result)
@@ -758,7 +758,7 @@ func TestRecursiveListSecretWithLogical_NilSecretList_V2(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "2")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "2")
 	// When secretList is nil, an empty slice should be returned
 	if len(result) != 0 {
 		t.Errorf("recursiveListSecretWithLogical() expected empty slice when list returns nil, got %v", result)
@@ -768,7 +768,7 @@ func TestRecursiveListSecretWithLogical_NilSecretList_V2(t *testing.T) {
 func TestRecursiveListSecretWithLogical_UnsupportedVersion(t *testing.T) {
 	mock := &mockVaultLogical{}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "unsupported")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "unsupported")
 	// For unsupported version, an empty slice should be returned since listSecretWithLogical returns nil
 	if len(result) != 0 {
 		t.Errorf("recursiveListSecretWithLogical() expected empty slice for unsupported version, got %v", result)
@@ -786,7 +786,7 @@ func TestRecursiveListSecretWithLogical_KeysNotSlice(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "1")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "1")
 	if len(result) != 0 {
 		t.Errorf("recursiveListSecretWithLogical() expected empty slice when keys is not a slice, got %v", result)
 	}
@@ -803,7 +803,7 @@ func TestRecursiveListSecretWithLogical_KeyNotString(t *testing.T) {
 		},
 	}
 
-	result := recursiveListSecretWithLogical(mock, "/secret", "", "1")
+	result := recursiveListSecretWithLogical(context.Background(), mock, "/secret", "", "1")
 	// Should skip the non-string key and only return the valid one
 	if len(result) != 1 {
 		t.Errorf("recursiveListSecretWithLogical() expected 1 result, got %d: %v", len(result), result)
@@ -1719,6 +1719,23 @@ func TestHealthCheck_ConnectionRefused(t *testing.T) {
 	err = client.HealthCheck(context.Background())
 	if err == nil {
 		t.Error("HealthCheck() expected error for connection refused")
+	}
+}
+
+func TestGetValues_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	mock := &mockVaultLogical{
+		readRawFunc: func(path string) (*vaultapi.Response, error) {
+			return nil, ctx.Err()
+		},
+	}
+
+	client := &Client{logical: mock}
+	_, err := client.GetValues(ctx, []string{"/secret/data"})
+	if err == nil {
+		t.Error("GetValues() with cancelled context: expected error, got nil")
 	}
 }
 

--- a/pkg/backends/zookeeper/client.go
+++ b/pkg/backends/zookeeper/client.go
@@ -40,15 +40,76 @@ func NewZookeeperClient(machines []string, dialTimeout time.Duration) (*Client, 
 	}, nil
 }
 
-func nodeWalk(prefix string, c *Client, vars map[string]string) error {
+// childrenWithContext wraps Children with context cancellation support.
+// Uses a buffered channel so the goroutine can exit even if ctx is done first.
+func (c *Client) childrenWithContext(ctx context.Context, path string) ([]string, *zk.Stat, error) {
+	type result struct {
+		children []string
+		stat     *zk.Stat
+		err      error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		l, s, err := c.client.Children(path)
+		ch <- result{l, s, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case r := <-ch:
+		return r.children, r.stat, r.err
+	}
+}
+
+// getWithContext wraps Get with context cancellation support.
+func (c *Client) getWithContext(ctx context.Context, path string) ([]byte, *zk.Stat, error) {
+	type result struct {
+		data []byte
+		stat *zk.Stat
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		b, s, err := c.client.Get(path)
+		ch <- result{b, s, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case r := <-ch:
+		return r.data, r.stat, r.err
+	}
+}
+
+// existsWithContext wraps Exists with context cancellation support.
+func (c *Client) existsWithContext(ctx context.Context, path string) (bool, *zk.Stat, error) {
+	type result struct {
+		exists bool
+		stat   *zk.Stat
+		err    error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ok, s, err := c.client.Exists(path)
+		ch <- result{ok, s, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return false, nil, ctx.Err()
+	case r := <-ch:
+		return r.exists, r.stat, r.err
+	}
+}
+
+func nodeWalk(ctx context.Context, prefix string, c *Client, vars map[string]string) error {
 	var s string
-	l, stat, err := c.client.Children(prefix)
+	l, stat, err := c.childrenWithContext(ctx, prefix)
 	if err != nil {
 		return err
 	}
 
 	if stat.NumChildren == 0 {
-		b, _, err := c.client.Get(prefix)
+		b, _, err := c.getWithContext(ctx, prefix)
 		if err != nil {
 			return err
 		}
@@ -61,18 +122,18 @@ func nodeWalk(prefix string, c *Client, vars map[string]string) error {
 			} else {
 				s = prefix + "/" + key
 			}
-			_, stat, err := c.client.Exists(s)
+			_, stat, err := c.existsWithContext(ctx, s)
 			if err != nil {
 				return err
 			}
 			if stat.NumChildren == 0 {
-				b, _, err := c.client.Get(s)
+				b, _, err := c.getWithContext(ctx, s)
 				if err != nil {
 					return err
 				}
 				vars[s] = string(b)
 			} else {
-				if err := nodeWalk(s, c, vars); err != nil {
+				if err := nodeWalk(ctx, s, c, vars); err != nil {
 					return err
 				}
 			}
@@ -85,11 +146,11 @@ func (c *Client) GetValues(ctx context.Context, keys []string) (map[string]strin
 	vars := make(map[string]string)
 	for _, v := range keys {
 		v = strings.Replace(v, "/*", "", -1)
-		_, _, err := c.client.Exists(v)
+		_, _, err := c.existsWithContext(ctx, v)
 		if err != nil {
 			return vars, err
 		}
-		err = nodeWalk(v, c, vars)
+		err = nodeWalk(ctx, v, c, vars)
 		if err != nil {
 			return vars, err
 		}

--- a/pkg/backends/zookeeper/client_test.go
+++ b/pkg/backends/zookeeper/client_test.go
@@ -599,5 +599,36 @@ func TestHealthCheck_Error(t *testing.T) {
 	}
 }
 
+func TestGetValues_ContextCancellation(t *testing.T) {
+	// Block inside Exists until the test signals, then check ctx is respected.
+	ready := make(chan struct{})
+	mock := &mockZkConn{
+		existsFunc: func(path string) (bool, *zk.Stat, error) {
+			<-ready // block until unblocked
+			return true, &zk.Stat{}, nil
+		},
+	}
+
+	client := &Client{client: mock}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.GetValues(ctx, []string{"/app/key"})
+		errCh <- err
+	}()
+
+	// Cancel context while GetValues is blocked inside existsWithContext.
+	cancel()
+
+	// Unblock the mock so its goroutine can exit.
+	close(ready)
+
+	err := <-errCh
+	if err != context.Canceled {
+		t.Errorf("GetValues() with cancelled context: error = %v, want context.Canceled", err)
+	}
+}
+
 // Note: Full integration tests require a running Zookeeper instance.
 // These are covered by integration tests in .github/workflows/integration-tests.yml


### PR DESCRIPTION
## Summary

- Vault: update `vaultLogical` interface to use `*WithContext` variants (`ListWithContext`, `ReadWithContext`, `ReadRawWithContext`, `WriteWithContext`) and thread `ctx` through `GetValues`, `listSecretWithLogical`, and `recursiveListSecretWithLogical` — `--backend-timeout` and caller cancellation now take effect for all Vault operations
- Zookeeper: the `go-zookeeper` library has no native context support; added `childrenWithContext`, `getWithContext`, and `existsWithContext` wrappers using goroutine + buffered channel (size 1) + select — buffered channel prevents goroutine leaks when context is cancelled mid-flight; threaded `ctx` through `nodeWalk` and `GetValues`
- Added context cancellation regression tests for both backends

## Test Plan

- [x] `go test ./pkg/backends/vault/... ./pkg/backends/zookeeper/...` passes
- [x] `go test ./...` passes (full suite)
- [ ] Integration tests: vault (approle, kv-v1, kv-v2) and zookeeper

Closes #551