### PR TITLE
fix: non-blocking errChan sends in watch goroutines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* fix: Non-blocking errChan sends in monitorPrefix and monitorForBatch — prevents watch goroutines from stalling under error bursts when all backends fail simultaneously; dropped errors are logged at Warning level (#560)
+
 * fix: Propagate context through Vault and Zookeeper GetValues — `--backend-timeout` and caller cancellation now take effect for Vault (updated vaultLogical interface to use `*WithContext` variants) and Zookeeper (goroutine+select wrappers for blocking calls) (#566)
 
 * fix: Close cached per-resource backend clients on shutdown — prevents connection/resource leaks when template resources override the global backend; lock is released before Close() to prevent deadlock (#564)

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -12,6 +12,17 @@ import (
 	util "github.com/abtreece/confd/pkg/util"
 )
 
+// trySendErr attempts a non-blocking send of err to ch.
+// If ch is full, it logs a warning that includes dest so operators can identify
+// which template resource triggered the drop.
+func trySendErr(ch chan error, err error, dest string) {
+	select {
+	case ch <- err:
+	default:
+		log.Warning("error dropped (errChan full) for %s: %s", dest, err)
+	}
+}
+
 // Processor defines the interface for template processing strategies.
 type Processor interface {
 	Process()
@@ -246,7 +257,7 @@ func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
 				log.Debug("Context cancelled, stopping watch for %s", t.Dest)
 				return
 			}
-			p.errChan <- err
+			trySendErr(p.errChan, err, t.Dest)
 			// Prevent backend errors from consuming all resources.
 			time.Sleep(p.config.WatchErrorBackoff)
 			continue
@@ -269,7 +280,7 @@ func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
 				// Debounce period elapsed, process the template
 				log.Debug("Debounce period elapsed for %s, processing", t.Dest)
 				if err := t.process(); err != nil {
-					p.errChan <- err
+					trySendErr(p.errChan, err, t.Dest)
 				}
 			case <-p.internalStop:
 				return
@@ -285,7 +296,7 @@ func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
 			default:
 				// No debouncing, process immediately
 				if err := t.process(); err != nil {
-					p.errChan <- err
+					trySendErr(p.errChan, err, t.Dest)
 				}
 			}
 		}
@@ -415,7 +426,7 @@ func (p *batchWatchProcessor) monitorForBatch(t *TemplateResource) {
 				log.Debug("Context cancelled, stopping batch watch for %s", t.Dest)
 				return
 			}
-			p.errChan <- err
+			trySendErr(p.errChan, err, t.Dest)
 			time.Sleep(p.config.WatchErrorBackoff)
 			continue
 		}

--- a/pkg/template/processor_test.go
+++ b/pkg/template/processor_test.go
@@ -1,8 +1,123 @@
 package template
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/abtreece/confd/pkg/backends"
+	"github.com/abtreece/confd/pkg/log"
 )
+
+// erroringStoreClient is a mock StoreClient that returns errors from WatchPrefix
+// immediately unless the context is cancelled or the stop channel is closed.
+type erroringStoreClient struct{}
+
+func (c *erroringStoreClient) GetValues(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (c *erroringStoreClient) WatchPrefix(ctx context.Context, _ string, _ []string, _ uint64, stopChan chan bool) (uint64, error) {
+	select {
+	case <-stopChan:
+		return 0, errors.New("watch stopped")
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+		return 0, errors.New("simulated backend error")
+	}
+}
+
+func (c *erroringStoreClient) HealthCheck(_ context.Context) error { return nil }
+func (c *erroringStoreClient) Close() error                        { return nil }
+
+var _ backends.StoreClient = (*erroringStoreClient)(nil)
+
+// TestMonitorPrefix_NonBlockingErrChan verifies that monitorPrefix does not
+// deadlock when errChan is full. With the old blocking send (p.errChan <- err),
+// the goroutine would stall on the first error when there is no reader. After
+// the fix (non-blocking select), errors are dropped and the goroutine exits
+// cleanly when the context is cancelled.
+func TestMonitorPrefix_NonBlockingErrChan(t *testing.T) {
+	// Suppress the expected "error dropped" Warning logs — this test intentionally
+	// floods errChan to verify the goroutine doesn't deadlock, so dropped-error
+	// warnings are noise rather than signal here.
+	log.SetLevel("error")
+	t.Cleanup(func() { log.SetLevel("info") })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	p := &watchProcessor{
+		config: Config{
+			Ctx:               ctx,
+			WatchErrorBackoff: time.Millisecond,
+		},
+		errChan:      make(chan error), // unbuffered, no reader — fills instantly
+		internalStop: make(chan bool),
+	}
+
+	tr := &TemplateResource{
+		storeClient:  &erroringStoreClient{},
+		prefixedKeys: []string{"/test"},
+		Dest:         "/tmp/test.conf",
+	}
+
+	p.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.monitorPrefix(tr)
+	}()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly — non-blocking errChan confirmed
+	case <-time.After(time.Second):
+		t.Fatal("monitorPrefix blocked on full errChan (deadlock regression)")
+	}
+}
+
+// TestMonitorForBatch_NonBlockingErrChan verifies that monitorForBatch does not
+// deadlock when errChan is full, using the same approach as TestMonitorPrefix_NonBlockingErrChan.
+func TestMonitorForBatch_NonBlockingErrChan(t *testing.T) {
+	log.SetLevel("error")
+	t.Cleanup(func() { log.SetLevel("info") })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	p := &batchWatchProcessor{
+		config: Config{
+			Ctx:               ctx,
+			WatchErrorBackoff: time.Millisecond,
+		},
+		errChan:      make(chan error), // unbuffered, no reader
+		changeChan:   make(chan *TemplateResource, 1),
+		internalStop: make(chan bool),
+	}
+
+	tr := &TemplateResource{
+		storeClient:  &erroringStoreClient{},
+		prefixedKeys: []string{"/test"},
+		Dest:         "/tmp/test.conf",
+	}
+
+	p.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.monitorForBatch(tr)
+	}()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly
+	case <-time.After(time.Second):
+		t.Fatal("monitorForBatch blocked on full errChan (deadlock regression)")
+	}
+}
 
 func TestIntervalProcessor_Creation(t *testing.T) {
 	config := Config{}

--- a/vendor/github.com/go-jose/go-jose/v4/asymmetric.go
+++ b/vendor/github.com/go-jose/go-jose/v4/asymmetric.go
@@ -414,6 +414,9 @@ func (ctx ecKeyGenerator) genKey() ([]byte, rawHeader, error) {
 
 // Decrypt the given payload and return the content encryption key.
 func (ctx ecDecrypterSigner) decryptKey(headers rawHeader, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+	if recipient == nil {
+		return nil, errors.New("go-jose/go-jose: missing recipient")
+	}
 	epk, err := headers.getEPK()
 	if err != nil {
 		return nil, errors.New("go-jose/go-jose: invalid epk header")
@@ -461,13 +464,18 @@ func (ctx ecDecrypterSigner) decryptKey(headers rawHeader, recipient *recipientI
 		return nil, ErrUnsupportedAlgorithm
 	}
 
+	encryptedKey := recipient.encryptedKey
+	if len(encryptedKey) == 0 {
+		return nil, errors.New("go-jose/go-jose: missing JWE Encrypted Key")
+	}
+
 	key := deriveKey(string(algorithm), keySize)
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
 
-	return josecipher.KeyUnwrap(block, recipient.encryptedKey)
+	return josecipher.KeyUnwrap(block, encryptedKey)
 }
 
 func (ctx edDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm) (Signature, error) {

--- a/vendor/github.com/go-jose/go-jose/v4/cipher/key_wrap.go
+++ b/vendor/github.com/go-jose/go-jose/v4/cipher/key_wrap.go
@@ -66,12 +66,20 @@ func KeyWrap(block cipher.Block, cek []byte) ([]byte, error) {
 }
 
 // KeyUnwrap implements NIST key unwrapping; it unwraps a content encryption key (cek) with the given block cipher.
+//
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.4
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.8
 func KeyUnwrap(block cipher.Block, ciphertext []byte) ([]byte, error) {
+	n := (len(ciphertext) / 8) - 1
+	if n <= 0 {
+		return nil, errors.New("go-jose/go-jose: JWE Encrypted Key too short")
+	}
+
 	if len(ciphertext)%8 != 0 {
 		return nil, errors.New("go-jose/go-jose: key wrap input must be 8 byte blocks")
 	}
 
-	n := (len(ciphertext) / 8) - 1
 	r := make([][]byte, n)
 
 	for i := range r {

--- a/vendor/github.com/go-jose/go-jose/v4/symmetric.go
+++ b/vendor/github.com/go-jose/go-jose/v4/symmetric.go
@@ -366,11 +366,21 @@ func (ctx *symmetricKeyCipher) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 
 // Decrypt the content encryption key.
 func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
-	switch headers.getAlgorithm() {
-	case DIRECT:
-		cek := make([]byte, len(ctx.key))
-		copy(cek, ctx.key)
-		return cek, nil
+	if recipient == nil {
+		return nil, fmt.Errorf("go-jose/go-jose: missing recipient")
+	}
+
+	alg := headers.getAlgorithm()
+	if alg == DIRECT {
+		return bytes.Clone(ctx.key), nil
+	}
+
+	encryptedKey := recipient.encryptedKey
+	if len(encryptedKey) == 0 {
+		return nil, fmt.Errorf("go-jose/go-jose: missing JWE Encrypted Key")
+	}
+
+	switch alg {
 	case A128GCMKW, A192GCMKW, A256GCMKW:
 		aead := newAESGCM(len(ctx.key))
 
@@ -385,7 +395,7 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 
 		parts := &aeadParts{
 			iv:         iv.bytes(),
-			ciphertext: recipient.encryptedKey,
+			ciphertext: encryptedKey,
 			tag:        tag.bytes(),
 		}
 
@@ -401,7 +411,7 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 			return nil, err
 		}
 
-		cek, err := josecipher.KeyUnwrap(block, recipient.encryptedKey)
+		cek, err := josecipher.KeyUnwrap(block, encryptedKey)
 		if err != nil {
 			return nil, err
 		}
@@ -445,7 +455,7 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 			return nil, err
 		}
 
-		cek, err := josecipher.KeyUnwrap(block, recipient.encryptedKey)
+		cek, err := josecipher.KeyUnwrap(block, encryptedKey)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -253,7 +253,7 @@ github.com/felixge/httpsnoop
 ## explicit; go 1.17
 github.com/fsnotify/fsnotify
 github.com/fsnotify/fsnotify/internal
-# github.com/go-jose/go-jose/v4 v4.1.3
+# github.com/go-jose/go-jose/v4 v4.1.4
 ## explicit; go 1.24.0
 github.com/go-jose/go-jose/v4
 github.com/go-jose/go-jose/v4/cipher


### PR DESCRIPTION
## Summary

- Replaces blocking `p.errChan <- err` with non-blocking `select/default` in `monitorPrefix` and `monitorForBatch`
- Under a burst of backend errors (e.g. network partition), N watch goroutines could all stall on a full channel send, delaying error recovery until the main loop drained it
- Dropped errors are logged at `Warning` level; `WatchErrorBackoff` already rate-limits individual goroutines so drops are bounded

## Details

The buffered `errChan` (capacity 10 in `cli.go`) can fill quickly when many templates all hit backend errors simultaneously. With N resources and a network partition, all N `monitorPrefix` goroutines attempt `p.errChan <- err` — any goroutine beyond the 10th blocks indefinitely, halting watch advancement until the main loop reads.

Startup/reload fatal-error sends (lines 94, 117, 159, 344) are intentionally left blocking — they occur before any watch goroutines are running so the buffer cannot be full at that point.

Closes #560

## Test plan

- [x] Two new regression tests added: `TestMonitorPrefix_NonBlockingErrChan` and `TestMonitorForBatch_NonBlockingErrChan`
- [x] Both use an unbuffered errChan with no reader — the exact condition that caused deadlock with the old code
- [x] Tests failed before fix, pass after
- [x] Full test suite passes (`go test ./...`)