### PR TITLE
fix: stat ConfigDir not ConfDir in getTemplateResources

### DIFF
--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -527,8 +527,8 @@ func (p *batchWatchProcessor) processBatch() {
 func getTemplateResources(config Config) ([]*TemplateResource, error) {
 	var lastError error
 	log.Debug("Loading template resources from confdir %s", config.ConfDir)
-	if _, err := os.Stat(config.ConfDir); err != nil {
-		log.Warning("Cannot load template resources: confdir '%s': %v", config.ConfDir, err)
+	if _, err := os.Stat(config.ConfigDir); err != nil {
+		log.Warning("Cannot load template resources: config dir '%s': %v", config.ConfigDir, err)
 		return nil, nil
 	}
 	paths, err := util.RecursiveFilesLookup(config.ConfigDir, "*toml")

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -526,7 +526,7 @@ func (p *batchWatchProcessor) processBatch() {
 
 func getTemplateResources(config Config) ([]*TemplateResource, error) {
 	var lastError error
-	log.Debug("Loading template resources from confdir %s", config.ConfDir)
+	log.Debug("Loading template resources from config dir %s", config.ConfigDir)
 	if _, err := os.Stat(config.ConfigDir); err != nil {
 		log.Warning("Cannot load template resources: config dir '%s': %v", config.ConfigDir, err)
 		return nil, nil

--- a/pkg/template/processor_test.go
+++ b/pkg/template/processor_test.go
@@ -172,14 +172,34 @@ func TestProcess_NilTemplateResources(t *testing.T) {
 	}
 }
 
-func TestGetTemplateResources_NonExistentConfDir(t *testing.T) {
+func TestGetTemplateResources_NonExistentConfigDir(t *testing.T) {
 	config := Config{
 		ConfDir:   "/nonexistent/path",
 		ConfigDir: "/nonexistent/path/conf.d",
 	}
 
 	templates, err := getTemplateResources(config)
-	// Should return nil, nil when confdir doesn't exist (logs warning)
+	// Should return nil, nil when config dir doesn't exist (logs warning)
+	if err != nil {
+		t.Errorf("getTemplateResources() unexpected error: %v", err)
+	}
+	if templates != nil {
+		t.Errorf("getTemplateResources() = %v, want nil", templates)
+	}
+}
+
+func TestGetTemplateResources_ConfDirExistsConfigDirMissing(t *testing.T) {
+	// Regression test for: ConfDir existence check passing when ConfigDir is absent.
+	// Previously, getTemplateResources statted ConfDir but scanned ConfigDir.
+	// If ConfDir existed but ConfigDir did not, the check passed silently and
+	// RecursiveFilesLookup returned a confusing EvalSymlinks error.
+	confDir := t.TempDir() // ConfDir exists
+	config := Config{
+		ConfDir:   confDir,
+		ConfigDir: confDir + "/conf.d", // ConfigDir does not exist
+	}
+
+	templates, err := getTemplateResources(config)
 	if err != nil {
 		t.Errorf("getTemplateResources() unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `getTemplateResources` was checking existence of `ConfDir` (e.g. `/etc/confd`) but then scanning `ConfigDir` (e.g. `/etc/confd/conf.d`)
- If `ConfDir` existed but `ConfigDir` did not, the guard passed silently and `RecursiveFilesLookup` returned a confusing `EvalSymlinks` error
- Fix: stat `ConfigDir` instead, with an updated log message to match
- Adds a regression test (`TestGetTemplateResources_ConfDirExistsConfigDirMissing`) covering the split-existence case

## Test plan

- [x] `go test -run TestGetTemplateResources ./pkg/template/ -v` — all three `TestGetTemplateResources_*` tests pass
- [x] `make test` passes