### PR TITLE
fix: resolve gosec code scanning alerts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 ### Unreleased
 
+* fix: Resolve gosec code scanning alerts (2026-04-18) (#578)
+  - Suppress false positives with `#nosec` annotations for G117, G204, G304, G703, G115 — all operator-configured paths/commands or internal-only hash input
+  - Handle previously unhandled errors from `Close()` and `os.Remove()` calls in redis, vault, and template packages with warning/error logging
+  - Extract `closePubSubLocked()` and `removeStageFile()` helpers to deduplicate repeated cleanup patterns
+
 ### v0.41.0 (2026-04-18)
 
 * fix: Windows support — skip chown and owner/group lookup on Windows (#574)

--- a/pkg/backends/etcd/client.go
+++ b/pkg/backends/etcd/client.go
@@ -148,7 +148,7 @@ func NewEtcdClient(machines []string, cert, key, caCert string, clientInsecure b
 	}
 
 	if caCert != "" {
-		certBytes, err := os.ReadFile(caCert)
+		certBytes, err := os.ReadFile(caCert) // #nosec G304 -- caCert is operator-configured TLS path
 		if err != nil {
 			return &Client{}, fmt.Errorf("failed to read CA certificate file: %w", err)
 		}
@@ -368,7 +368,7 @@ func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, 
 	notify := make(chan int64)
 	// Wait for all watches
 	for _, v := range watches {
-		go v.WaitNext(watchCtx, int64(waitIndex), notify)
+		go v.WaitNext(watchCtx, int64(waitIndex), notify) // #nosec G115 -- etcd revisions are int64 internally; uint64 overflow is not reachable in practice
 	}
 	select {
 	case nextRevision := <-notify:

--- a/pkg/backends/file/client.go
+++ b/pkg/backends/file/client.go
@@ -36,7 +36,7 @@ func NewFileClient(filepath []string, filter string) (*Client, error) {
 }
 
 func readFile(path string, vars map[string]string) error {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is from configured filepath list, not user input
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", path, err)
 	}

--- a/pkg/backends/redis/client.go
+++ b/pkg/backends/redis/client.go
@@ -393,6 +393,17 @@ func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, 
 	}
 }
 
+// closePubSubLocked closes and nils c.pubsub, logging any error.
+// Must be called with c.pubsubMu held.
+func (c *Client) closePubSubLocked() {
+	if c.pubsub != nil {
+		if err := c.pubsub.Close(); err != nil {
+			log.Warning("Failed to close Redis PubSub: %v", err)
+		}
+		c.pubsub = nil
+	}
+}
+
 // stopWatch cancels the long-lived watch goroutine and cleans up resources.
 func (c *Client) stopWatch() {
 	c.pubsubMu.Lock()
@@ -403,10 +414,7 @@ func (c *Client) stopWatch() {
 		c.watchCancel = nil
 		c.watchCtx = nil
 	}
-	if c.pubsub != nil {
-		c.pubsub.Close()
-		c.pubsub = nil
-	}
+	c.closePubSubLocked()
 	// Clear watched prefixes so they can be re-registered if watch restarts
 	c.watchedPrefixes = make(map[string]struct{})
 }
@@ -433,10 +441,7 @@ func (c *Client) watchWithReconnect(ctx context.Context) {
 
 	defer func() {
 		c.pubsubMu.Lock()
-		if c.pubsub != nil {
-			c.pubsub.Close()
-			c.pubsub = nil
-		}
+		c.closePubSubLocked()
 		// Clear watchCtx/watchCancel so a new watcher can be started if needed.
 		// Only clear if they still refer to this watcher's context to avoid
 		// racing with stopWatch() or a concurrently started new watcher.
@@ -446,7 +451,9 @@ func (c *Client) watchWithReconnect(ctx context.Context) {
 		}
 		c.pubsubMu.Unlock()
 		if rClient != nil {
-			rClient.Close()
+			if err := rClient.Close(); err != nil {
+				log.Warning("Failed to close Redis client: %v", err)
+			}
 		}
 	}()
 
@@ -527,13 +534,12 @@ func (c *Client) watchWithReconnect(ctx context.Context) {
 
 					// Clean up current connection before reconnecting
 					c.pubsubMu.Lock()
-					if c.pubsub != nil {
-						c.pubsub.Close()
-						c.pubsub = nil
-					}
+					c.closePubSubLocked()
 					c.pubsubMu.Unlock()
 					if rClient != nil {
-						rClient.Close()
+						if err := rClient.Close(); err != nil {
+							log.Warning("Failed to close Redis client during reconnect: %v", err)
+						}
 						rClient = nil
 					}
 

--- a/pkg/backends/vault/client.go
+++ b/pkg/backends/vault/client.go
@@ -244,7 +244,9 @@ func (c *Client) GetValues(ctx context.Context, paths []string) (map[string]stri
 		}
 
 		secret, err := vaultapi.ParseSecret(resp.Body)
-		resp.Body.Close() // Close immediately after parsing to avoid resource leak in loop
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warning("Failed to close Vault response body: %v", closeErr)
+		}
 		if err != nil {
 			log.Warning("failed to parse secret for %s: %v", mount, err)
 			errs = append(errs, fmt.Errorf("mount %s: failed to parse secret: %w", mount, err))

--- a/pkg/template/client_cache.go
+++ b/pkg/template/client_cache.go
@@ -68,7 +68,8 @@ func configHash(cfg backends.Config) string {
 	cfg.RetryMaxDelay = 0
 	cfg.IMDSCacheTTL = 0
 
-	// Marshal config to JSON for consistent hashing
+	// Marshal config to JSON for consistent hashing.
+	// #nosec G117 -- JSON is used only as SHA256 hash input, never logged or transmitted
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		// Fallback to a simple string representation

--- a/pkg/template/command_executor.go
+++ b/pkg/template/command_executor.go
@@ -190,11 +190,12 @@ func (e *commandExecutor) runCommandWithTimeout(cmd string, timeout time.Duratio
 		defer cancel()
 	}
 
+	// All commands are operator-configured via template resources, not user input.
 	var c *exec.Cmd
 	if runtime.GOOS == "windows" {
-		c = exec.CommandContext(ctx, "cmd", "/C", cmd)
+		c = exec.CommandContext(ctx, "cmd", "/C", cmd) // #nosec G204
 	} else {
-		c = exec.CommandContext(ctx, "/bin/sh", "-c", cmd)
+		c = exec.CommandContext(ctx, "/bin/sh", "-c", cmd) // #nosec G204
 		// Set up process group handling for proper child process cleanup
 		setupProcessGroup(c)
 	}
@@ -257,11 +258,12 @@ func (e *commandExecutor) runCommandWithTimeout(cmd string, timeout time.Duratio
 // It returns nil if the command returns 0, otherwise returns the error.
 func runCommand(cmd string) error {
 	log.Debug("Running %s", cmd)
+	// All commands are operator-configured via template resources, not user input.
 	var c *exec.Cmd
 	if runtime.GOOS == "windows" {
-		c = exec.Command("cmd", "/C", cmd)
+		c = exec.Command("cmd", "/C", cmd) // #nosec G204
 	} else {
-		c = exec.Command("/bin/sh", "-c", cmd)
+		c = exec.Command("/bin/sh", "-c", cmd) // #nosec G204
 	}
 
 	output, err := c.CombinedOutput()

--- a/pkg/template/file_stager.go
+++ b/pkg/template/file_stager.go
@@ -221,7 +221,7 @@ func (s *fileStager) writeToDestination(stagePath, destPath string) error {
 	logger := log.With("stage_path", stagePath, "dest_path", destPath)
 
 	readStart := time.Now()
-	contents, err := os.ReadFile(stagePath)
+	contents, err := os.ReadFile(stagePath) // #nosec G304 -- stagePath is an internal temp file created by confd
 	readDuration := time.Since(readStart)
 
 	if err != nil {
@@ -232,7 +232,7 @@ func (s *fileStager) writeToDestination(stagePath, destPath string) error {
 	}
 
 	writeStart := time.Now()
-	if err := os.WriteFile(destPath, contents, s.fileMode); err != nil {
+	if err := os.WriteFile(destPath, contents, s.fileMode); err != nil { // #nosec G703 -- destPath is operator-configured, not user input
 		logger.ErrorContext(context.Background(), "Failed to write to destination",
 			"duration_ms", time.Since(start).Milliseconds(),
 			"file_size_bytes", len(contents),

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -557,6 +557,6 @@ func (t *TemplateResource) setFileMode() error {
 // removeStageFile removes a staged temp file, logging any error.
 func removeStageFile(path string) {
 	if err := os.Remove(path); err != nil {
-		log.Error("Failed to remove stage file %s: %s", path, err)
+		log.Error("Failed to remove stage file %s: %v", path, err)
 	}
 }

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -345,7 +345,7 @@ func (t *TemplateResource) createStageFile() error {
 	// Validate output format if specified
 	if err := t.fmtValidator.validate(temp.Name()); err != nil {
 		// temp is already closed by fileStager.createStageFile()
-		os.Remove(temp.Name())
+		removeStageFile(temp.Name())
 		return err
 	}
 
@@ -391,7 +391,7 @@ func (t *TemplateResource) sync() error {
 		}
 		// Clean up stage file in noop mode
 		if !t.keepStageFile {
-			os.Remove(staged)
+			removeStageFile(staged)
 		}
 		return nil
 	}
@@ -400,7 +400,7 @@ func (t *TemplateResource) sync() error {
 	if !changed {
 		log.Debug("Target config %s in sync", t.Dest)
 		if !t.keepStageFile {
-			os.Remove(staged)
+			removeStageFile(staged)
 		}
 		return nil
 	}
@@ -410,7 +410,7 @@ func (t *TemplateResource) sync() error {
 	if !t.syncOnly && t.CheckCmd != "" {
 		if err := t.check(); err != nil {
 			if !t.keepStageFile {
-				os.Remove(staged)
+				removeStageFile(staged)
 			}
 			return fmt.Errorf("config check failed: %w", err)
 		}
@@ -552,4 +552,11 @@ func (t *TemplateResource) setFileMode() error {
 	}
 
 	return nil
+}
+
+// removeStageFile removes a staged temp file, logging any error.
+func removeStageFile(path string) {
+	if err := os.Remove(path); err != nil {
+		log.Error("Failed to remove stage file %s: %s", path, err)
+	}
 }


### PR DESCRIPTION
## Summary

- Suppress gosec false positives with `#nosec` annotations for G117, G204, G304, G703, and G115 — all are by-design behaviors (operator-configured commands/paths, internal hash input)
- Fix 8 unhandled errors (G104) from `Close()` and `os.Remove()` calls across redis, vault, and template packages — log warnings/errors rather than silently ignoring
- Extract `closePubSubLocked()` helper in redis client to deduplicate 3 identical pubsub close+log blocks
- Extract `removeStageFile()` helper in template resource to deduplicate 4 identical remove+log blocks

## Test plan

- [ ] `make test` passes (unit tests + linter)
- [ ] Verify code scanning alerts are resolved after CI runs gosec