### PR TITLE
fix: handle os.Remove errors when cleaning stage files

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,8 +48,9 @@ var (
 
 // File sync metrics
 var (
-	FileSyncTotal    *prometheus.CounterVec
-	FileChangedTotal prometheus.Counter
+	FileSyncTotal             *prometheus.CounterVec
+	FileChangedTotal          prometheus.Counter
+	StageFileCleanupErrors    prometheus.Counter
 )
 
 // Initialize creates and registers all metrics with a new registry.
@@ -258,6 +259,15 @@ func Initialize() {
 		},
 	)
 	Registry.MustRegister(FileChangedTotal)
+
+	StageFileCleanupErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "stage_file_cleanup_errors_total",
+			Help:      "Total number of errors encountered when removing stage files.",
+		},
+	)
+	Registry.MustRegister(StageFileCleanupErrors)
 }
 
 // Enabled returns true if metrics are enabled.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -153,6 +153,9 @@ func TestFileMetrics_Initialized(t *testing.T) {
 	if FileChangedTotal == nil {
 		t.Error("FileChangedTotal should not be nil")
 	}
+	if StageFileCleanupErrors == nil {
+		t.Error("StageFileCleanupErrors should not be nil")
+	}
 
 	// Cleanup
 	Registry = nil
@@ -183,6 +186,7 @@ func TestMetrics_CanBeRecorded(t *testing.T) {
 
 	FileSyncTotal.WithLabelValues("/etc/nginx/nginx.conf").Inc()
 	FileChangedTotal.Inc()
+	StageFileCleanupErrors.Inc()
 
 	// Verify we can gather metrics
 	metricFamilies, err := Registry.Gather()
@@ -201,6 +205,7 @@ func TestMetrics_CanBeRecorded(t *testing.T) {
 		"confd_backend_request_total",
 		"confd_template_process_total",
 		"confd_command_total",
+		"confd_stage_file_cleanup_errors_total",
 	}
 
 	for _, metric := range expectedMetrics {

--- a/pkg/template/file_stager.go
+++ b/pkg/template/file_stager.go
@@ -83,9 +83,7 @@ func (s *fileStager) createStageFile(destPath string, content []byte) (*os.File,
 		if closeErr := temp.Close(); closeErr != nil {
 			log.Error("Failed to close temp file during cleanup: %v", closeErr)
 		}
-		if removeErr := os.Remove(temp.Name()); removeErr != nil {
-			log.Error("Failed to remove temp file during cleanup: %v", removeErr)
-		}
+		removeStageFile(temp.Name())
 		logger.ErrorContext(context.Background(), "Failed to write to stage file",
 			"duration_ms", time.Since(start).Milliseconds(),
 			"write_duration_ms", time.Since(writeStart).Milliseconds(),
@@ -100,9 +98,7 @@ func (s *fileStager) createStageFile(destPath string, content []byte) (*os.File,
 		if closeErr := temp.Close(); closeErr != nil {
 			log.Error("Failed to close temp file during cleanup: %v", closeErr)
 		}
-		if removeErr := os.Remove(temp.Name()); removeErr != nil {
-			log.Error("Failed to remove temp file during cleanup: %v", removeErr)
-		}
+		removeStageFile(temp.Name())
 		logger.ErrorContext(context.Background(), "Failed to apply permissions",
 			"duration_ms", time.Since(start).Milliseconds(),
 			"error", err.Error())
@@ -113,9 +109,7 @@ func (s *fileStager) createStageFile(destPath string, content []byte) (*os.File,
 	// Close the file before returning - content is flushed to disk
 	// The file handle remains valid for Name() calls
 	if err := temp.Close(); err != nil {
-		if removeErr := os.Remove(temp.Name()); removeErr != nil {
-			log.Error("Failed to remove temp file during cleanup: %v", removeErr)
-		}
+		removeStageFile(temp.Name())
 		return nil, fmt.Errorf("failed to close stage file: %w", err)
 	}
 
@@ -174,7 +168,7 @@ func (s *fileStager) syncFiles(stagePath, destPath string) error {
 	}
 
 	// Otherwise, try atomic rename first (moves the file)
-	defer os.Remove(stagePath)
+	defer removeStageFile(stagePath)
 
 	renameStart := time.Now()
 	err := os.Rename(stagePath, destPath)

--- a/pkg/template/file_stager.go
+++ b/pkg/template/file_stager.go
@@ -255,6 +255,17 @@ func (s *fileStager) writeToDestination(stagePath, destPath string) error {
 	return nil
 }
 
+// removeStageFile removes a staged temp file. Cleanup failures are non-fatal
+// but logged and counted — they indicate filesystem issues worth observing.
+func removeStageFile(path string) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Warning("Failed to remove stage file %s: %v", path, err)
+		if metrics.Enabled() {
+			metrics.StageFileCleanupErrors.Inc()
+		}
+	}
+}
+
 // showDiffOutput generates and displays a diff between the staged and destination files.
 func (s *fileStager) showDiffOutput(stagePath, destPath string) error {
 	diff, err := util.GenerateDiff(stagePath, destPath, s.diffContext)

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -554,13 +554,3 @@ func (t *TemplateResource) setFileMode() error {
 	return nil
 }
 
-// removeStageFile removes a staged temp file. Cleanup failures are non-fatal
-// but logged and counted since they indicate filesystem issues worth observing.
-func removeStageFile(path string) {
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		log.Warning("Failed to remove stage file %s: %v", path, err)
-		if metrics.Enabled() {
-			metrics.StageFileCleanupErrors.Inc()
-		}
-	}
-}

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -554,9 +554,13 @@ func (t *TemplateResource) setFileMode() error {
 	return nil
 }
 
-// removeStageFile removes a staged temp file, logging any error.
+// removeStageFile removes a staged temp file. Cleanup failures are non-fatal
+// but logged and counted since they indicate filesystem issues worth observing.
 func removeStageFile(path string) {
-	if err := os.Remove(path); err != nil {
-		log.Error("Failed to remove stage file %s: %v", path, err)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Warning("Failed to remove stage file %s: %v", path, err)
+		if metrics.Enabled() {
+			metrics.StageFileCleanupErrors.Inc()
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces all bare `os.Remove` calls on stage files with a `removeStageFile` helper that silently ignores `ErrNotExist`, logs a warning for other errors, and increments a new `stage_file_cleanup_errors_total` Prometheus counter
- Covers 7 call sites across `resource.go` and `file_stager.go` (4 in `sync`/`createStageFile`, 3 error-path cleanups in `createStageFile`, 1 deferred cleanup in `syncFiles`)
- Helper lives in `file_stager.go` alongside all other staging logic

Closes #556

## Test plan

- [x] `make test` passes
- [ ] Verify `stage_file_cleanup_errors_total` appears in `/metrics` when metrics are enabled
- [ ] Confirm no spurious warnings on normal sync cycles (ErrNotExist suppressed after atomic rename)