### PR TITLE
chore: ignore root-level confd binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+confd
 dist/
 plans/
 


### PR DESCRIPTION
## Summary

- Adds `confd` to `.gitignore` to cover the case where `go build` is run directly in the repo root (producing `./confd`) rather than via `make build` (which outputs to `bin/confd`, already ignored)

## Test plan

- [x] `confd` binary no longer appears as untracked after a root-level `go build`