### PR TITLE
perf: skip stage file write when rendered content is unchanged

### DIFF
--- a/pkg/template/file_stager.go
+++ b/pkg/template/file_stager.go
@@ -2,7 +2,7 @@ package template
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/md5" // #nosec G501 -- MD5 used for change detection, not security
 	"errors"
 	"fmt"
 	"io"

--- a/pkg/template/file_stager.go
+++ b/pkg/template/file_stager.go
@@ -95,8 +95,8 @@ func (s *fileStager) contentUnchanged(rendered []byte, destPath string) (bool, e
 		return false, err
 	}
 
-	// Mode mismatch — permissions need updating.
-	if destStat.Mode().Perm() != s.fileMode {
+	// Mode mismatch — permissions or special mode bits need updating.
+	if destStat.Mode() != s.fileMode {
 		return false, nil
 	}
 

--- a/pkg/template/file_stager.go
+++ b/pkg/template/file_stager.go
@@ -2,8 +2,10 @@ package template
 
 import (
 	"context"
+	"crypto/md5"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,6 +60,63 @@ func newFileStager(config fileStagingConfig) *fileStager {
 // This is called after setFileMode() determines the final mode.
 func (s *fileStager) updateFileMode(mode os.FileMode) {
 	s.fileMode = mode
+}
+
+// md5Bytes returns the MD5 hex digest of b.
+// MD5 is used for fast change detection, not cryptographic security.
+func md5Bytes(b []byte) string { // #nosec G401 -- MD5 used for change detection, not security
+	h := md5.New()
+	h.Write(b)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// computeDestMD5 computes the MD5 hash of a file and returns it as a hex string.
+func computeDestMD5(path string) (string, error) {
+	f, err := os.Open(path) // #nosec G304 -- path is an operator-configured dest file
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := md5.New() // #nosec G401 -- MD5 used for change detection, not security
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// contentUnchanged reports whether rendered content is identical to the dest file,
+// including file mode and ownership. Returns false (must write) when dest does not exist.
+func (s *fileStager) contentUnchanged(rendered []byte, destPath string) (bool, error) {
+	destStat, err := os.Stat(destPath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Mode mismatch — permissions need updating.
+	if destStat.Mode().Perm() != s.fileMode {
+		return false, nil
+	}
+
+	// Ownership mismatch (platform-specific; always true on Windows).
+	if !destOwnershipMatches(destStat, s.uid, s.gid) {
+		return false, nil
+	}
+
+	// Fast path: size differs means content differs.
+	if destStat.Size() != int64(len(rendered)) {
+		return false, nil
+	}
+
+	// Compare content via MD5.
+	destMD5, err := computeDestMD5(destPath)
+	if err != nil {
+		return false, err
+	}
+
+	return md5Bytes(rendered) == destMD5, nil
 }
 
 // createStageFile creates a temporary stage file in the destination directory

--- a/pkg/template/file_stager_test.go
+++ b/pkg/template/file_stager_test.go
@@ -526,6 +526,115 @@ func TestCreateStageFile_EmptyContent(t *testing.T) {
 	}
 }
 
+func TestContentUnchanged_DestNotExist(t *testing.T) {
+	stager := newFileStager(fileStagingConfig{
+		Uid:      os.Getuid(),
+		Gid:      os.Getegid(),
+		FileMode: 0644,
+	})
+	unchanged, err := stager.contentUnchanged([]byte("content"), "/nonexistent/path/file.conf")
+	if err != nil {
+		t.Errorf("contentUnchanged() unexpected error: %v", err)
+	}
+	if unchanged {
+		t.Error("contentUnchanged() should return false when dest does not exist")
+	}
+}
+
+func TestContentUnchanged_SameContent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — mode bits not enforced")
+	}
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "dest.conf")
+	content := []byte("hello world")
+	if err := os.WriteFile(destPath, content, 0644); err != nil {
+		t.Fatalf("Failed to write dest file: %v", err)
+	}
+
+	stager := newFileStager(fileStagingConfig{
+		Uid:      os.Getuid(),
+		Gid:      os.Getegid(),
+		FileMode: 0644,
+	})
+	unchanged, err := stager.contentUnchanged(content, destPath)
+	if err != nil {
+		t.Errorf("contentUnchanged() unexpected error: %v", err)
+	}
+	if !unchanged {
+		t.Error("contentUnchanged() should return true when content and metadata match")
+	}
+}
+
+func TestContentUnchanged_DifferentContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "dest.conf")
+	if err := os.WriteFile(destPath, []byte("old content"), 0644); err != nil {
+		t.Fatalf("Failed to write dest file: %v", err)
+	}
+
+	stager := newFileStager(fileStagingConfig{
+		Uid:      os.Getuid(),
+		Gid:      os.Getegid(),
+		FileMode: 0644,
+	})
+	unchanged, err := stager.contentUnchanged([]byte("new content"), destPath)
+	if err != nil {
+		t.Errorf("contentUnchanged() unexpected error: %v", err)
+	}
+	if unchanged {
+		t.Error("contentUnchanged() should return false when content differs")
+	}
+}
+
+func TestContentUnchanged_DifferentMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — mode bits not enforced")
+	}
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "dest.conf")
+	content := []byte("same content")
+	if err := os.WriteFile(destPath, content, 0644); err != nil {
+		t.Fatalf("Failed to write dest file: %v", err)
+	}
+
+	// stager expects 0600 but dest has 0644
+	stager := newFileStager(fileStagingConfig{
+		Uid:      os.Getuid(),
+		Gid:      os.Getegid(),
+		FileMode: 0600,
+	})
+	unchanged, err := stager.contentUnchanged(content, destPath)
+	if err != nil {
+		t.Errorf("contentUnchanged() unexpected error: %v", err)
+	}
+	if unchanged {
+		t.Error("contentUnchanged() should return false when file mode differs")
+	}
+}
+
+func TestContentUnchanged_SameSizeDifferentContent(t *testing.T) {
+	// Verify MD5 check catches same-length content changes
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "dest.conf")
+	if err := os.WriteFile(destPath, []byte("aaa"), 0644); err != nil {
+		t.Fatalf("Failed to write dest file: %v", err)
+	}
+
+	stager := newFileStager(fileStagingConfig{
+		Uid:      os.Getuid(),
+		Gid:      os.Getegid(),
+		FileMode: 0644,
+	})
+	unchanged, err := stager.contentUnchanged([]byte("bbb"), destPath) // same length, different content
+	if err != nil {
+		t.Errorf("contentUnchanged() unexpected error: %v", err)
+	}
+	if unchanged {
+		t.Error("contentUnchanged() should return false when content differs (same size)")
+	}
+}
+
 func TestSyncFiles_ErrorReading(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "file-stager-test-")
 	if err != nil {

--- a/pkg/template/file_stager_unix.go
+++ b/pkg/template/file_stager_unix.go
@@ -2,9 +2,22 @@
 
 package template
 
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
 // chownFile sets the owner and group of the named file.
 func chownFile(path string, uid, gid int) error {
 	return os.Chown(path, uid, gid)
+}
+
+// destOwnershipMatches reports whether the dest file's uid and gid match
+// the expected values. Returns false if the syscall info is unavailable.
+func destOwnershipMatches(stat os.FileInfo, uid, gid int) bool {
+	sys, ok := stat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return int(sys.Uid) == uid && int(sys.Gid) == gid
 }

--- a/pkg/template/file_stager_windows.go
+++ b/pkg/template/file_stager_windows.go
@@ -2,7 +2,14 @@
 
 package template
 
+import "os"
+
 // chownFile is a no-op on Windows (no uid/gid ownership concept).
 func chownFile(_ string, _, _ int) error {
 	return nil
+}
+
+// destOwnershipMatches is a no-op on Windows (no uid/gid ownership concept).
+func destOwnershipMatches(_ os.FileInfo, _, _ int) bool {
+	return true
 }

--- a/pkg/template/resource.go
+++ b/pkg/template/resource.go
@@ -314,37 +314,17 @@ func (t *TemplateResource) setVars() error {
 	return t.bkndFetcher.fetchValues()
 }
 
-// createStageFile stages the src configuration file by processing the src
-// template and setting the desired owner, group, and mode. It also sets the
-// StageFile for the template resource.
-// It returns an error if any.
-func (t *TemplateResource) createStageFile() error {
-	// Ensure FileMode is set and fileStager is updated.
-	// This defensive check is needed for backward compatibility with tests that:
-	// 1. Call createStageFile() directly without going through process()
-	// 2. Set FileMode directly on TemplateResource after construction
-	// TODO: Refactor tests to use process() or a test helper to avoid this check
-	if t.FileMode == 0 || (t.fileStgr != nil && t.fileStgr.fileMode != t.FileMode) {
-		if err := t.setFileMode(); err != nil {
-			return err
-		}
-	}
-
-	// Render the template to bytes
-	rendered, err := t.tmplRenderer.render(t.Src)
-	if err != nil {
-		return err
-	}
-
-	// Create stage file with rendered content
+// createStageFile stages the src configuration file using pre-rendered content.
+// It writes the rendered bytes to a temp file in the destination directory,
+// applies configured permissions, and validates the output format if set.
+// It sets StageFile on success.
+func (t *TemplateResource) createStageFile(rendered []byte) error {
 	temp, err := t.fileStgr.createStageFile(t.Dest, rendered)
 	if err != nil {
 		return err
 	}
 
-	// Validate output format if specified
 	if err := t.fmtValidator.validate(temp.Name()); err != nil {
-		// temp is already closed by fileStager.createStageFile()
 		removeStageFile(temp.Name())
 		return err
 	}
@@ -491,11 +471,8 @@ func (t *TemplateResource) reload() error {
 }
 
 
-// process is a convenience function that wraps calls to the three main tasks
-// required to keep local configuration files in sync. First we gather vars
-// from the store, then we stage a candidate configuration file, and finally sync
-// things up.
-// It returns an error if any.
+// process gathers vars from the backend, renders the template to bytes, and
+// syncs the destination file only when content or metadata has changed.
 func (t *TemplateResource) process() error {
 	start := time.Now()
 	var err error
@@ -517,7 +494,26 @@ func (t *TemplateResource) process() error {
 	if err = t.setVars(); err != nil {
 		return err
 	}
-	if err = t.createStageFile(); err != nil {
+
+	// Render template to bytes before touching disk.
+	var rendered []byte
+	rendered, err = t.tmplRenderer.render(t.Src)
+	if err != nil {
+		return err
+	}
+
+	// Fast path: skip stage file entirely when content and metadata are unchanged.
+	var unchanged bool
+	unchanged, err = t.fileStgr.contentUnchanged(rendered, t.Dest)
+	if err != nil {
+		return err
+	}
+	if unchanged {
+		log.Debug("Target config %s in sync", t.Dest)
+		return nil
+	}
+
+	if err = t.createStageFile(rendered); err != nil {
 		return err
 	}
 	if err = t.sync(); err != nil {

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1302,5 +1303,87 @@ func TestResolveOwnership_ExplicitValues(t *testing.T) {
 	}
 	if gid != 43 {
 		t.Errorf("resolveOwnership() gid = %d, want 43", gid)
+	}
+}
+
+func TestProcess_SkipsStageFileWhenUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows — file mode bits not enforced")
+	}
+
+	tempConfDir, err := createTempDirs()
+	if err != nil {
+		t.Fatalf("Failed to create temp dirs: %s", err)
+	}
+	defer os.RemoveAll(tempConfDir)
+
+	// Write a template that produces static content.
+	srcTemplate := filepath.Join(tempConfDir, "templates", "static.tmpl")
+	if err := os.WriteFile(srcTemplate, []byte("static content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write dest file with the same content process() will produce.
+	destFile, err := os.CreateTemp("", "confd-process-test-*.conf")
+	if err != nil {
+		t.Fatalf("Failed to create dest file: %v", err)
+	}
+	destFile.WriteString("static content")
+	destFile.Close()
+	defer os.Remove(destFile.Name())
+	os.Chmod(destFile.Name(), 0644)
+
+	// Record mtime before process() runs.
+	infoBefore, err := os.Stat(destFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to stat dest file before: %v", err)
+	}
+	mtimeBefore := infoBefore.ModTime()
+
+	resourceContent := fmt.Sprintf(`[template]
+src = "static.tmpl"
+dest = "%s"
+keys = []
+`, filepath.ToSlash(destFile.Name()))
+
+	resourcePath := filepath.Join(tempConfDir, "conf.d", "static.toml")
+	if err := os.WriteFile(resourcePath, []byte(resourceContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeClient, err := env.NewEnvClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr, err := NewTemplateResource(resourcePath, Config{
+		ConfDir:     tempConfDir,
+		ConfigDir:   filepath.Join(tempConfDir, "conf.d"),
+		StoreClient: storeClient,
+		TemplateDir: filepath.Join(tempConfDir, "templates"),
+	})
+	if err != nil {
+		t.Fatalf("NewTemplateResource failed: %s", err)
+	}
+
+	if err := tr.process(); err != nil {
+		t.Fatalf("process() unexpected error: %v", err)
+	}
+
+	// Primary assertion: StageFile must not have been created.
+	// This is more reliable than mtime comparison (mtime resolution varies by filesystem).
+	if tr.StageFile != nil {
+		t.Errorf("process() should not set StageFile when content is unchanged, got %s", tr.StageFile.Name())
+		os.Remove(tr.StageFile.Name())
+	}
+
+	// Secondary assertion: dest file must not have been touched (mtime unchanged).
+	// Note: mtime resolution is filesystem-dependent; the StageFile check above is authoritative.
+	infoAfter, err := os.Stat(destFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to stat dest file after: %v", err)
+	}
+	if !infoAfter.ModTime().Equal(mtimeBefore) {
+		t.Logf("process() mtime changed after no-op run (filesystem resolution may vary; StageFile check above is authoritative)")
 	}
 }

--- a/pkg/template/resource_test.go
+++ b/pkg/template/resource_test.go
@@ -1328,10 +1328,16 @@ func TestProcess_SkipsStageFileWhenUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create dest file: %v", err)
 	}
-	destFile.WriteString("static content")
-	destFile.Close()
+	if _, err := destFile.WriteString("static content"); err != nil {
+		t.Fatalf("Failed to write dest file: %v", err)
+	}
+	if err := destFile.Close(); err != nil {
+		t.Fatalf("Failed to close dest file: %v", err)
+	}
 	defer os.Remove(destFile.Name())
-	os.Chmod(destFile.Name(), 0644)
+	if err := os.Chmod(destFile.Name(), 0644); err != nil {
+		t.Fatalf("Failed to chmod dest file: %v", err)
+	}
 
 	// Record mtime before process() runs.
 	infoBefore, err := os.Stat(destFile.Name())

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -567,7 +567,15 @@ func ExecuteTestTemplate(tt templateTest, t *testing.T) {
 
 	tt.updateStore(tr)
 
-	if err := tr.createStageFile(); err != nil {
+	// Sync the fileStager's mode with the FileMode set directly on the resource.
+	tr.fileStgr.updateFileMode(tr.FileMode)
+
+	rendered, err := tr.tmplRenderer.render(tr.Src)
+	if err != nil {
+		t.Errorf("%s: failed to render template: %s", tt.desc, err.Error())
+	}
+
+	if err := tr.createStageFile(rendered); err != nil {
 		t.Errorf("%s: failed createStageFile: %s", tt.desc, err.Error())
 	}
 
@@ -632,6 +640,8 @@ func templateResource() (*TemplateResource, error) {
 		return nil, err
 	}
 	tr.Dest = "./test/tmp/test.conf"
+	// Direct FileMode assignment bypasses setFileMode(), so callers must invoke
+	// tr.fileStgr.updateFileMode(tr.FileMode) to keep the stager synchronized.
 	tr.FileMode = 0666
 	return tr, nil
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -572,7 +572,7 @@ func ExecuteTestTemplate(tt templateTest, t *testing.T) {
 
 	rendered, err := tr.tmplRenderer.render(tr.Src)
 	if err != nil {
-		t.Errorf("%s: failed to render template: %s", tt.desc, err.Error())
+		t.Fatalf("%s: failed to render template: %s", tt.desc, err.Error())
 	}
 
 	if err := tr.createStageFile(rendered); err != nil {


### PR DESCRIPTION
## Summary

- Adds `contentUnchanged()` to `fileStager`: compares rendered template bytes against the dest file (mode + ownership + size + MD5) before creating a staging file
- Refactors `process()` to render first, check `contentUnchanged()`, and early-return without staging on the no-change path
- Refactors `createStageFile()` to accept pre-rendered `[]byte` — the render call now lives in `process()` before the content check

## Impact

On the no-change path (the dominant case in steady-state), eliminates temp file I/O:
- 1 temp file create + write
- 1 temp file rename (or copy)
- 1 temp file delete

The check itself performs 1 `stat` and reads the dest file once for MD5 comparison — both of which replace the equivalent operations that previously happened inside staging. Net: same reads, zero temp file writes.

For a daemon with 20 templates on a 10s interval where configs rarely change: ~7,200 temp file writes and deletes per hour eliminated.

## Test Plan

- [ ] `go test ./pkg/template/ -run TestContentUnchanged` — 5 unit tests covering: dest not exist, same content, different content, mode mismatch, same-size-different-content
- [ ] `go test ./pkg/template/ -run TestProcess_SkipsStageFileWhenUnchanged` — test asserting no staging occurs when rendered content matches dest
- [ ] `make test` — full suite passes

Closes #548