### PR TITLE
refactor: extract shared AWS SDK init helper into awsutil package

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,12 @@
   - Eliminates temp file create/write/rename/delete on the common steady-state no-change path
   - Closes #548
 
+* refactor: Extract shared AWS SDK init helper into awsutil package (2026-04-19) (#587)
+  - Add `pkg/backends/awsutil.LoadAWSConfig` centralizing region detection (env → IMDS → SDK defaults), config loading, and credential validation
+  - Migrate acm, ssm, secretsmanager, and dynamodb backends to use the shared helper, removing ~120 lines of duplicated boilerplate
+  - Add `dialTimeout` parameter to `dynamodb.NewDynamoDBClient` for consistency with other AWS backends
+  - Closes #549
+
 * chore: Ignore root-level confd binary in .gitignore (2026-04-18) (#580)
 
 * fix: Handle os.Remove errors when cleaning stage files (2026-04-18) (#579)

--- a/pkg/backends/acm/client.go
+++ b/pkg/backends/acm/client.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/abtreece/confd/pkg/backends/awsutil"
 	"github.com/abtreece/confd/pkg/backends/types"
 	"github.com/abtreece/confd/pkg/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 )
 
@@ -32,48 +31,11 @@ type Client struct {
 func New(exportPrivateKey bool, dialTimeout time.Duration) (*Client, error) {
 	ctx := context.Background()
 
-	// Defaults already applied via ApplyTimeoutDefaults in the factory
-	// Attempt to get AWS Region from environment first, then EC2 metadata
-	var region string
-	if os.Getenv("AWS_REGION") != "" {
-		region = os.Getenv("AWS_REGION")
-	} else {
-		// Try to get region from EC2 metadata with a timeout
-		imdsCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-		defer cancel()
-
-		imdsClient := imds.New(imds.Options{})
-		regionOutput, err := imdsClient.GetRegion(imdsCtx, &imds.GetRegionInput{})
-		if err == nil {
-			region = regionOutput.Region
-		} else {
-			return nil, fmt.Errorf("failed to get region from EC2 metadata: %w", err)
-		}
-	}
-
-	// Build config options
-	var optFns []func(*config.LoadOptions) error
-	if region != "" {
-		optFns = append(optFns, config.WithRegion(region))
-	}
-
-	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
+	cfg, err := awsutil.LoadAWSConfig(ctx, dialTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		return nil, err
 	}
 
-	log.Debug("Region: %s", cfg.Region)
-
-	// Fail early if no credentials can be found
-	creds, err := cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
-	}
-	if !creds.HasKeys() {
-		return nil, fmt.Errorf("no AWS credentials found")
-	}
-
-	// Create ACM client with optional local endpoint
 	var acmOpts []func(*acm.Options)
 	if os.Getenv("ACM_LOCAL") != "" {
 		log.Debug("ACM_LOCAL is set")
@@ -83,7 +45,6 @@ func New(exportPrivateKey bool, dialTimeout time.Duration) (*Client, error) {
 		})
 	}
 
-	// If export private key is enabled, require passphrase
 	var passphrase []byte
 	if exportPrivateKey {
 		passphraseStr := os.Getenv("ACM_PASSPHRASE")

--- a/pkg/backends/awsutil/awsutil.go
+++ b/pkg/backends/awsutil/awsutil.go
@@ -1,0 +1,58 @@
+package awsutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/abtreece/confd/pkg/log"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+)
+
+// LoadAWSConfig loads AWS SDK config with automatic region detection.
+//
+// Region resolution order:
+//  1. AWS_REGION environment variable
+//  2. EC2 IMDS (if dialTimeout > 0 and AWS_REGION is not set)
+//  3. SDK defaults (AWS_DEFAULT_REGION, profile, etc.)
+//
+// Returns an error if AWS config cannot be loaded or if no credentials are found.
+func LoadAWSConfig(ctx context.Context, dialTimeout time.Duration) (aws.Config, error) {
+	var region string
+	if v := os.Getenv("AWS_REGION"); v != "" {
+		region = v
+	} else if dialTimeout > 0 {
+		imdsCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+		c := imds.New(imds.Options{})
+		if out, err := c.GetRegion(imdsCtx, &imds.GetRegionInput{}); err == nil {
+			region = out.Region
+		}
+		// IMDS failure is silently ignored; SDK may resolve region from other sources.
+	}
+
+	var opts []func(*config.LoadOptions) error
+	if region != "" {
+		opts = append(opts, config.WithRegion(region))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	log.Debug("Region: %s", cfg.Region)
+
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
+	}
+	if !creds.HasKeys() {
+		return aws.Config{}, fmt.Errorf("no AWS credentials found")
+	}
+
+	return cfg, nil
+}

--- a/pkg/backends/awsutil/awsutil_test.go
+++ b/pkg/backends/awsutil/awsutil_test.go
@@ -1,0 +1,89 @@
+// Use white-box package to call LoadAWSConfig directly without import qualifier.
+package awsutil
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// setEnv sets env vars for a test, unsets those mapped to "", and restores all on cleanup.
+func setEnv(t *testing.T, pairs map[string]string) {
+	t.Helper()
+	originals := make(map[string]string, len(pairs))
+	for k, v := range pairs {
+		originals[k] = os.Getenv(k)
+		if v == "" {
+			os.Unsetenv(k)
+		} else {
+			os.Setenv(k, v)
+		}
+	}
+	t.Cleanup(func() {
+		for k, orig := range originals {
+			if orig == "" {
+				os.Unsetenv(k)
+			} else {
+				os.Setenv(k, orig)
+			}
+		}
+	})
+}
+
+func TestLoadAWSConfig_RegionFromEnv(t *testing.T) {
+	setEnv(t, map[string]string{
+		"AWS_REGION":            "us-west-2",
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	})
+
+	cfg, err := LoadAWSConfig(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("LoadAWSConfig() unexpected error: %v", err)
+	}
+	if cfg.Region != "us-west-2" {
+		t.Errorf("cfg.Region = %q, want %q", cfg.Region, "us-west-2")
+	}
+}
+
+func TestLoadAWSConfig_RegionFromEnvWithPositiveDialTimeout(t *testing.T) {
+	// When AWS_REGION is set, IMDS is not consulted regardless of dialTimeout.
+	// dialTimeout > 0 enables the IMDS branch, but AWS_REGION short-circuits it.
+	// This test runs quickly because the IMDS call is never made.
+	setEnv(t, map[string]string{
+		"AWS_REGION":            "ap-southeast-1",
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	})
+
+	cfg, err := LoadAWSConfig(context.Background(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("LoadAWSConfig() unexpected error: %v", err)
+	}
+	if cfg.Region != "ap-southeast-1" {
+		t.Errorf("cfg.Region = %q, want %q", cfg.Region, "ap-southeast-1")
+	}
+}
+
+func TestLoadAWSConfig_NoCredentials(t *testing.T) {
+	// Clear all known credential sources to ensure the no-credentials path is exercised.
+	// Container/IRSA credential sources must also be cleared to avoid flakiness on EC2/ECS.
+	setEnv(t, map[string]string{
+		"AWS_REGION":                             "us-east-1",
+		"AWS_ACCESS_KEY_ID":                      "",
+		"AWS_SECRET_ACCESS_KEY":                  "",
+		"AWS_SESSION_TOKEN":                      "",
+		"AWS_PROFILE":                            "nonexistent-profile-xyz",
+		"AWS_CONFIG_FILE":                        "/dev/null",
+		"AWS_SHARED_CREDENTIALS_FILE":            "/dev/null",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI":     "",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "",
+		"AWS_WEB_IDENTITY_TOKEN_FILE":            "",
+	})
+
+	_, err := LoadAWSConfig(context.Background(), 0)
+	if err == nil {
+		t.Fatal("LoadAWSConfig() expected error for missing credentials, got nil")
+	}
+}

--- a/pkg/backends/awsutil/awsutil_test.go
+++ b/pkg/backends/awsutil/awsutil_test.go
@@ -9,11 +9,17 @@ import (
 )
 
 // setEnv sets env vars for a test, unsets those mapped to "", and restores all on cleanup.
+// Uses os.LookupEnv so it can distinguish "unset" from "set to empty string".
 func setEnv(t *testing.T, pairs map[string]string) {
 	t.Helper()
-	originals := make(map[string]string, len(pairs))
+	type saved struct {
+		value   string
+		present bool
+	}
+	originals := make(map[string]saved, len(pairs))
 	for k, v := range pairs {
-		originals[k] = os.Getenv(k)
+		val, ok := os.LookupEnv(k)
+		originals[k] = saved{value: val, present: ok}
 		if v == "" {
 			os.Unsetenv(k)
 		} else {
@@ -22,10 +28,10 @@ func setEnv(t *testing.T, pairs map[string]string) {
 	}
 	t.Cleanup(func() {
 		for k, orig := range originals {
-			if orig == "" {
+			if !orig.present {
 				os.Unsetenv(k)
 			} else {
-				os.Setenv(k, orig)
+				os.Setenv(k, orig.value)
 			}
 		}
 	})
@@ -75,8 +81,8 @@ func TestLoadAWSConfig_NoCredentials(t *testing.T) {
 		"AWS_SECRET_ACCESS_KEY":                  "",
 		"AWS_SESSION_TOKEN":                      "",
 		"AWS_PROFILE":                            "nonexistent-profile-xyz",
-		"AWS_CONFIG_FILE":                        "/dev/null",
-		"AWS_SHARED_CREDENTIALS_FILE":            "/dev/null",
+		"AWS_CONFIG_FILE":                        os.DevNull,
+		"AWS_SHARED_CREDENTIALS_FILE":            os.DevNull,
 		"AWS_CONTAINER_CREDENTIALS_FULL_URI":     "",
 		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "",
 		"AWS_WEB_IDENTITY_TOKEN_FILE":            "",

--- a/pkg/backends/client.go
+++ b/pkg/backends/client.go
@@ -101,7 +101,7 @@ func New(config Config) (StoreClient, error) {
 	case "dynamodb":
 		table := config.Table
 		log.Info("DynamoDB table set to %s", table)
-		return dynamodb.NewDynamoDBClient(table)
+		return dynamodb.NewDynamoDBClient(table, config.DialTimeout)
 	case "ssm":
 		return ssm.New(config.DialTimeout)
 	case "imds":

--- a/pkg/backends/dynamodb/client.go
+++ b/pkg/backends/dynamodb/client.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/abtreece/confd/pkg/backends/awsutil"
 	"github.com/abtreece/confd/pkg/backends/types"
 	"github.com/abtreece/confd/pkg/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
@@ -29,30 +29,16 @@ type Client struct {
 	table  string
 }
 
-// NewDynamoDBClient returns an *dynamodb.Client with a connection to the region
-// configured via the AWS_REGION environment variable.
-// It returns an error if the connection cannot be made or the table does not exist.
-func NewDynamoDBClient(table string) (*Client, error) {
+// NewDynamoDBClient returns a *Client connected to DynamoDB.
+// It validates that the specified table exists before returning.
+func NewDynamoDBClient(table string, dialTimeout time.Duration) (*Client, error) {
 	ctx := context.Background()
 
-	// Build config options
-	var optFns []func(*config.LoadOptions) error
-
-	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
+	cfg, err := awsutil.LoadAWSConfig(ctx, dialTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		return nil, err
 	}
 
-	// Fail early if no credentials can be found
-	creds, err := cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
-	}
-	if !creds.HasKeys() {
-		return nil, fmt.Errorf("no AWS credentials found")
-	}
-
-	// Create DynamoDB client with optional local endpoint
 	var ddbOpts []func(*dynamodb.Options)
 	if os.Getenv("DYNAMODB_LOCAL") != "" {
 		log.Debug("DYNAMODB_LOCAL is set")
@@ -64,7 +50,6 @@ func NewDynamoDBClient(table string) (*Client, error) {
 
 	d := dynamodb.NewFromConfig(cfg, ddbOpts...)
 
-	// Check if the table exists
 	_, err = d.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: &table})
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe table %s: %w", table, err)

--- a/pkg/backends/secretsmanager/client.go
+++ b/pkg/backends/secretsmanager/client.go
@@ -46,7 +46,7 @@ func New(versionStage string, noFlatten bool, dialTimeout time.Duration) (*Clien
 	}
 
 	if cfg.Region == "" {
-		return nil, errors.New("AWS region not found. Set AWS_REGION environment variable or run on EC2")
+		return nil, errors.New("AWS region not found. Configure a region via AWS SDK defaults such as AWS_REGION, AWS_DEFAULT_REGION, shared config/profile settings, or an instance/task role environment")
 	}
 
 	var smOpts []func(*secretsmanager.Options)

--- a/pkg/backends/secretsmanager/client.go
+++ b/pkg/backends/secretsmanager/client.go
@@ -10,11 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/abtreece/confd/pkg/backends/awsutil"
 	"github.com/abtreece/confd/pkg/backends/types"
 	"github.com/abtreece/confd/pkg/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
@@ -37,53 +36,19 @@ type Client struct {
 func New(versionStage string, noFlatten bool, dialTimeout time.Duration) (*Client, error) {
 	ctx := context.Background()
 
-	// Default version stage to AWSCURRENT
 	if versionStage == "" {
 		versionStage = "AWSCURRENT"
 	}
 
-	// Defaults already applied via ApplyTimeoutDefaults in the factory
-	// Attempt to get AWS Region from environment first, then EC2 metadata
-	var region string
-	if os.Getenv("AWS_REGION") != "" {
-		region = os.Getenv("AWS_REGION")
-	} else {
-		// Try to get region from EC2 metadata with a timeout
-		imdsCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-		defer cancel()
-
-		imdsClient := imds.New(imds.Options{})
-		regionOutput, err := imdsClient.GetRegion(imdsCtx, &imds.GetRegionInput{})
-		if err == nil {
-			region = regionOutput.Region
-		}
+	cfg, err := awsutil.LoadAWSConfig(ctx, dialTimeout)
+	if err != nil {
+		return nil, err
 	}
 
-	if region == "" {
+	if cfg.Region == "" {
 		return nil, errors.New("AWS region not found. Set AWS_REGION environment variable or run on EC2")
 	}
 
-	// Build config options
-	var optFns []func(*config.LoadOptions) error
-	optFns = append(optFns, config.WithRegion(region))
-
-	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %w", err)
-	}
-
-	log.Debug("Region: %s", cfg.Region)
-
-	// Fail early if no credentials can be found
-	creds, err := cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
-	}
-	if !creds.HasKeys() {
-		return nil, fmt.Errorf("no AWS credentials found")
-	}
-
-	// Create Secrets Manager client with optional local endpoint
 	var smOpts []func(*secretsmanager.Options)
 	if os.Getenv("SECRETSMANAGER_LOCAL") != "" {
 		log.Debug("SECRETSMANAGER_LOCAL is set")

--- a/pkg/backends/ssm/client.go
+++ b/pkg/backends/ssm/client.go
@@ -7,11 +7,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/abtreece/confd/pkg/backends/awsutil"
 	"github.com/abtreece/confd/pkg/backends/types"
 	"github.com/abtreece/confd/pkg/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 )
@@ -32,46 +31,11 @@ type Client struct {
 func New(dialTimeout time.Duration) (*Client, error) {
 	ctx := context.Background()
 
-	// Defaults already applied via ApplyTimeoutDefaults in the factory
-	// Attempt to get AWS Region from environment first, then EC2 metadata
-	var region string
-	if os.Getenv("AWS_REGION") != "" {
-		region = os.Getenv("AWS_REGION")
-	} else {
-		// Try to get region from EC2 metadata with a timeout
-		imdsCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-		defer cancel()
-
-		imdsClient := imds.New(imds.Options{})
-		regionOutput, err := imdsClient.GetRegion(imdsCtx, &imds.GetRegionInput{})
-		if err == nil {
-			region = regionOutput.Region
-		}
-	}
-
-	// Build config options
-	var optFns []func(*config.LoadOptions) error
-	if region != "" {
-		optFns = append(optFns, config.WithRegion(region))
-	}
-
-	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
+	cfg, err := awsutil.LoadAWSConfig(ctx, dialTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		return nil, err
 	}
 
-	log.Debug("Region: %s", cfg.Region)
-
-	// Fail early if no credentials can be found
-	creds, err := cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve AWS credentials: %w", err)
-	}
-	if !creds.HasKeys() {
-		return nil, fmt.Errorf("no AWS credentials found")
-	}
-
-	// Create SSM client with optional local endpoint
 	var ssmOpts []func(*ssm.Options)
 	if os.Getenv("SSM_LOCAL") != "" {
 		log.Debug("SSM_LOCAL is set")


### PR DESCRIPTION
## Summary

- Adds `pkg/backends/awsutil` with a single exported `LoadAWSConfig(ctx, dialTimeout)` function that centralizes AWS SDK initialization: region detection (env → IMDS → SDK defaults), `config.LoadDefaultConfig`, and credential validation
- Migrates acm, ssm, secretsmanager, and dynamodb backends to use `awsutil.LoadAWSConfig`, removing ~30 lines of duplicated boilerplate from each
- Adds `dialTimeout` parameter to `dynamodb.NewDynamoDBClient` (previously omitted; factory now passes `config.DialTimeout` consistently with other AWS backends)

**Behavior change (acm):** ACM previously hard-failed if IMDS region lookup failed when `AWS_REGION` was unset. The normalized behavior silently ignores IMDS failure, allowing SDK defaults (`AWS_DEFAULT_REGION`, profile region) to satisfy the requirement.

## Test Plan

- [ ] `go test ./pkg/backends/awsutil/...` — 3 new unit tests for `LoadAWSConfig`
- [ ] `go test ./pkg/backends/acm/... ./pkg/backends/ssm/... ./pkg/backends/secretsmanager/... ./pkg/backends/dynamodb/...` — all existing backend tests pass unchanged
- [ ] `go test ./...` — full suite green
- [ ] `make build` — builds cleanly
- [ ] No new lint issues (`make lint` exits with same 56 pre-existing findings)