### PR TITLE
refactor: deduplicate no-op WatchPrefix and Close across polling-only backends

### DIFF
--- a/pkg/backends/acm/client.go
+++ b/pkg/backends/acm/client.go
@@ -184,7 +184,6 @@ func (c *Client) ListCertificates(ctx context.Context) ([]string, error) {
 	return certs, nil
 }
 
-
 // HealthCheck verifies the backend connection is healthy.
 // It attempts to list certificates to verify AWS credentials and connectivity.
 func (c *Client) HealthCheck(ctx context.Context) error {
@@ -244,4 +243,3 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 		},
 	}, nil
 }
-

--- a/pkg/backends/acm/client.go
+++ b/pkg/backends/acm/client.go
@@ -23,6 +23,8 @@ type acmAPI interface {
 }
 
 type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
 	client           acmAPI
 	exportPrivateKey bool
 	passphrase       []byte
@@ -182,15 +184,6 @@ func (c *Client) ListCertificates(ctx context.Context) ([]string, error) {
 	return certs, nil
 }
 
-// WatchPrefix is not implemented for ACM
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
-}
 
 // HealthCheck verifies the backend connection is healthy.
 // It attempts to list certificates to verify AWS credentials and connectivity.
@@ -252,7 +245,3 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 	}, nil
 }
 
-// Close is a no-op for this backend.
-func (c *Client) Close() error {
-	return nil
-}

--- a/pkg/backends/dynamodb/client.go
+++ b/pkg/backends/dynamodb/client.go
@@ -25,6 +25,8 @@ type dynamoDBAPI interface {
 // Client is a wrapper around the DynamoDB client
 // and also holds the table to lookup key value pairs from
 type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
 	client dynamoDBAPI
 	table  string
 }
@@ -70,7 +72,7 @@ func NewDynamoDBClient(table string) (*Client, error) {
 		return nil, fmt.Errorf("failed to describe table %s: %w", table, err)
 	}
 
-	return &Client{d, table}, nil
+	return &Client{client: d, table: table}, nil
 }
 
 // GetValues retrieves the values for the given keys from DynamoDB
@@ -133,16 +135,6 @@ func (c *Client) GetValues(ctx context.Context, keys []string) (map[string]strin
 		}
 	}
 	return vars, nil
-}
-
-// WatchPrefix is not implemented
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
 }
 
 // HealthCheck verifies the backend connection is healthy.
@@ -208,9 +200,4 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 			"item_count":   fmt.Sprintf("%d", itemCount),
 		},
 	}, nil
-}
-
-// Close is a no-op for this backend.
-func (c *Client) Close() error {
-	return nil
 }

--- a/pkg/backends/env/client.go
+++ b/pkg/backends/env/client.go
@@ -14,7 +14,10 @@ import (
 var replacer = strings.NewReplacer("/", "_")
 
 // Client provides a shell for the env client
-type Client struct{}
+type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
+}
 
 // NewEnvClient returns a new client
 func NewEnvClient() (*Client, error) {
@@ -56,14 +59,6 @@ func clean(key string) string {
 	return cleanReplacer.Replace(strings.ToLower(newKey))
 }
 
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
-}
 
 // HealthCheck verifies the backend is healthy.
 // Environment variables are always available, so this always returns nil.
@@ -99,7 +94,3 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 	}, nil
 }
 
-// Close is a no-op for this backend.
-func (c *Client) Close() error {
-	return nil
-}

--- a/pkg/backends/env/client.go
+++ b/pkg/backends/env/client.go
@@ -59,7 +59,6 @@ func clean(key string) string {
 	return cleanReplacer.Replace(strings.ToLower(newKey))
 }
 
-
 // HealthCheck verifies the backend is healthy.
 // Environment variables are always available, so this always returns nil.
 func (c *Client) HealthCheck(ctx context.Context) error {
@@ -93,4 +92,3 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 		},
 	}, nil
 }
-

--- a/pkg/backends/imds/client.go
+++ b/pkg/backends/imds/client.go
@@ -25,6 +25,8 @@ type imdsAPI interface {
 
 // Client provides access to AWS EC2 Instance Metadata Service
 type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
 	client   imdsAPI
 	cache    *metadataCache
 	cacheTTL time.Duration
@@ -333,16 +335,6 @@ func (c *Client) getUserData(ctx context.Context) (string, error) {
 	return string(content), nil
 }
 
-// WatchPrefix is not supported for IMDS (polling only)
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
-}
-
 // HealthCheck performs a basic health check
 func (c *Client) HealthCheck(ctx context.Context) error {
 	output, err := c.client.GetMetadata(ctx, &imds.GetMetadataInput{
@@ -387,9 +379,4 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 	result.Details["cache_ttl"] = c.cacheTTL.String()
 
 	return result, nil
-}
-
-// Close closes the client (no-op for IMDS)
-func (c *Client) Close() error {
-	return nil
 }

--- a/pkg/backends/secretsmanager/client.go
+++ b/pkg/backends/secretsmanager/client.go
@@ -28,6 +28,8 @@ type secretsManagerAPI interface {
 
 // Client is a wrapper around the AWS Secrets Manager client.
 type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
 	client       secretsManagerAPI
 	versionStage string
 	noFlatten    bool
@@ -233,17 +235,6 @@ func (c *Client) fetchAndProcessSecret(ctx context.Context, secretName, key stri
 	return "", false, nil
 }
 
-// WatchPrefix is not implemented for Secrets Manager.
-// Secrets Manager does not support streaming/watching for changes.
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
-}
-
 // HealthCheck verifies the backend connection is healthy.
 // It lists secrets with a limit of 1 to verify AWS credentials and connectivity.
 // An empty list indicates success (no secrets exist but connectivity works).
@@ -320,9 +311,4 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 			"secret_count": fmt.Sprintf("%d", secretCount),
 		},
 	}, nil
-}
-
-// Close is a no-op for this backend.
-func (c *Client) Close() error {
-	return nil
 }

--- a/pkg/backends/ssm/client.go
+++ b/pkg/backends/ssm/client.go
@@ -25,6 +25,8 @@ type ssmAPI interface {
 
 // Client is a wrapper around the AWS SSM client.
 type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
 	client ssmAPI
 }
 
@@ -82,7 +84,7 @@ func New(dialTimeout time.Duration) (*Client, error) {
 	}
 
 	client := ssm.NewFromConfig(cfg, ssmOpts...)
-	return &Client{client}, nil
+	return &Client{client: client}, nil
 }
 
 // GetValues retrieves the values for the given keys from AWS SSM Parameter Store
@@ -144,16 +146,6 @@ func (c *Client) getParameter(ctx context.Context, name string) (map[string]stri
 	}
 	parameters[*resp.Parameter.Name] = *resp.Parameter.Value
 	return parameters, nil
-}
-
-// WatchPrefix is not implemented
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
 }
 
 // HealthCheck verifies the backend connection is healthy.
@@ -231,9 +223,4 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 			"parameter_count": fmt.Sprintf("%d", paramCount),
 		},
 	}, nil
-}
-
-// Close is a no-op for this backend.
-func (c *Client) Close() error {
-	return nil
 }

--- a/pkg/backends/types/noop.go
+++ b/pkg/backends/types/noop.go
@@ -4,7 +4,7 @@ import "context"
 
 // NoopWatcher is an embeddable struct for polling-only backends that do not
 // support watch mode. It blocks until the context is canceled or the stop
-// channel is closed.
+// channel receives a value or is closed.
 type NoopWatcher struct{}
 
 func (NoopWatcher) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {

--- a/pkg/backends/types/noop.go
+++ b/pkg/backends/types/noop.go
@@ -1,0 +1,25 @@
+package types
+
+import "context"
+
+// NoopWatcher is an embeddable struct for polling-only backends that do not
+// support watch mode. It blocks until the context is canceled or the stop
+// channel is closed.
+type NoopWatcher struct{}
+
+func (NoopWatcher) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
+	select {
+	case <-ctx.Done():
+		return waitIndex, ctx.Err()
+	case <-stopChan:
+		return waitIndex, nil
+	}
+}
+
+// NoopCloser is an embeddable struct for backends that hold no resources
+// requiring explicit cleanup.
+type NoopCloser struct{}
+
+func (NoopCloser) Close() error {
+	return nil
+}

--- a/pkg/backends/types/noop_test.go
+++ b/pkg/backends/types/noop_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestNoopWatcher_StopChan(t *testing.T) {
 	var w types.NoopWatcher
-	stopChan := make(chan bool, 1)
-	stopChan <- true
+	stopChan := make(chan bool)
+	close(stopChan)
 
 	idx, err := w.WatchPrefix(context.Background(), "/prefix", nil, 42, stopChan)
 	if err != nil {

--- a/pkg/backends/types/noop_test.go
+++ b/pkg/backends/types/noop_test.go
@@ -1,0 +1,44 @@
+package types_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/abtreece/confd/pkg/backends/types"
+)
+
+func TestNoopWatcher_StopChan(t *testing.T) {
+	var w types.NoopWatcher
+	stopChan := make(chan bool, 1)
+	stopChan <- true
+
+	idx, err := w.WatchPrefix(context.Background(), "/prefix", nil, 42, stopChan)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if idx != 42 {
+		t.Fatalf("expected waitIndex 42, got %d", idx)
+	}
+}
+
+func TestNoopWatcher_ContextCanceled(t *testing.T) {
+	var w types.NoopWatcher
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stopChan := make(chan bool)
+	idx, err := w.WatchPrefix(ctx, "/prefix", nil, 42, stopChan)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if idx != 42 {
+		t.Fatalf("expected waitIndex 42, got %d", idx)
+	}
+}
+
+func TestNoopCloser_Close(t *testing.T) {
+	var c types.NoopCloser
+	if err := c.Close(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}

--- a/pkg/backends/vault/client.go
+++ b/pkg/backends/vault/client.go
@@ -30,6 +30,8 @@ type vaultLogical interface {
 
 // Client is a wrapper around the vault client
 type Client struct {
+	types.NoopWatcher
+	types.NoopCloser
 	client  *vaultapi.Client
 	logical vaultLogical
 }
@@ -443,7 +445,6 @@ func recursiveListSecretWithLogical(ctx context.Context, logical vaultLogical, b
 	return results
 }
 
-
 func getMount(path string) string {
 	// Vault paths always use forward slashes regardless of OS
 	split := strings.Split(path, "/")
@@ -464,16 +465,6 @@ func uniqMounts(strSlice []string) []string {
 		}
 	}
 	return list
-}
-
-// WatchPrefix - not implemented at the moment
-func (c *Client) WatchPrefix(ctx context.Context, prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
-	select {
-	case <-ctx.Done():
-		return waitIndex, ctx.Err()
-	case <-stopChan:
-		return waitIndex, nil
-	}
 }
 
 // HealthCheck verifies the backend connection is healthy.
@@ -529,9 +520,4 @@ func (c *Client) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, 
 			"cluster_name": health.ClusterName,
 		},
 	}, nil
-}
-
-// Close is a no-op for this backend.
-func (c *Client) Close() error {
-	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `NoopWatcher` and `NoopCloser` embeddable structs to `pkg/backends/types/noop.go` — one canonical implementation of the no-op `WatchPrefix` (blocks on ctx/stopChan) and `Close() error { return nil }` used by all polling-only backends
- Migrates all 7 polling-only backends (acm, dynamodb, env, imds, secretsmanager, ssm, vault) to embed both structs, removing 14 identical method implementations
- No behavior changes — pure deduplication; polling-only nature of each backend is now explicit via the embedded type names

## Test Plan

- [ ] `go test ./pkg/backends/types/...` — 3 new unit tests for `NoopWatcher` (both select branches) and `NoopCloser`
- [ ] `go test ./...` — full suite green, all 7 migrated backends pass unchanged
- [ ] `make lint` — no new findings (baseline: 56 pre-existing)
- [ ] `make build` — builds cleanly
- [ ] `grep "func (c \*Client) WatchPrefix\|func (c \*Client) Close" pkg/backends/{acm,dynamodb,env,imds,secretsmanager,ssm,vault}/client.go` — no output

Closes #550