### PR TITLE
fix: match CHANGELOG headers with date suffix in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,12 @@ jobs:
           head -20 CHANGELOG
 
           # Extract section for this version from CHANGELOG
-          # Matches from "### vX.Y.Z" (with v prefix) until the next "### v" or end of file
+          # Matches "### vX.Y.Z" with optional date suffix e.g. "### v0.41.1 (2026-04-22)"
           awk -v tag="$TAG" '
             /^### v/ {
               if (found) exit
-              if ($0 == "### " tag) found=1
+              header = "### " tag
+              if ($0 == header || index($0, header " ") == 1) found=1
               next
             }
             found { print }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ env:
 before:
   hooks:
     - go mod tidy
+    - bash -c 'awk "/^### v{{ .Version }}/{found=1; next} /^### v/{if(found) exit} found" CHANGELOG > /tmp/release_header.md'
 builds:
   - main: ./cmd/confd
     binary: confd
@@ -117,6 +118,7 @@ changelog:
 
 release:
   prerelease: auto
+  header: /tmp/release_header.md
 
 dockers_v2:
   - images:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,6 @@ env:
 before:
   hooks:
     - go mod tidy
-    - bash -c 'awk "/^### v{{ .Version }}/{found=1; next} /^### v/{if(found) exit} found" CHANGELOG > /tmp/release_header.md'
 builds:
   - main: ./cmd/confd
     binary: confd
@@ -118,7 +117,6 @@ changelog:
 
 release:
   prerelease: auto
-  header: /tmp/release_header.md
 
 dockers_v2:
   - images:


### PR DESCRIPTION
## Summary

- Fix awk extraction in `release.yml` that failed to match CHANGELOG headers with date suffixes (e.g. `### v0.41.1 (2026-04-22)`)
- Use `index()` for exact string prefix matching with space boundary — avoids regex metachar issues and version prefix collisions
- Revert redundant goreleaser `before` hook and `release.header` since the release workflow already handles extraction via `gh release edit`

## Root cause

The release workflow used `$0 == "### " tag` which requires an exact line match, but CHANGELOG headers include a date suffix. This is why v0.41.1 published with empty release notes.

## Test plan

- [x] Verified awk extraction matches `### v0.41.1 (2026-04-22)` correctly
- [x] Verified `v0.41.10` does not false-match against `v0.41.1`
- [x] Verified regex metachar in dots (`v0X41X1`) no longer false-matches
- [x] `goreleaser check` validates config