### PR TITLE
[codex] consolidate Go version

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Run go test for coverage
         run: go test -vet=off ./... -race -coverprofile=coverage.out -covermode=atomic

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Run unit tests
         run: go test -mod=vendor ./pkg/... ./cmd/...

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Run E2E Tests
         run: go test -v -tags=e2e -timeout 15m ./test/e2e/...

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Build and Install
         run: |
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Build and Install
         run: |
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Build and Install
         run: |
@@ -235,7 +235,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Build and Install
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.2'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.8
+golang 1.26.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,33 @@
-@CLAUDE.md
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`confd` is a Go configuration management tool. The CLI entry point lives in `cmd/confd/`. Core packages are under `pkg/`: backend clients in `pkg/backends/`, template rendering in `pkg/template/`, logging in `pkg/log/`, metrics in `pkg/metrics/`, service helpers in `pkg/service/`, and utilities in `pkg/util/`. Unit tests sit beside source files as `*_test.go`. Integration tests live in `test/integration/`, with backend scripts under `test/integration/backends/` and shared fixtures under `test/integration/shared/`. User-facing docs are in `docs/`, examples in `examples/`, Docker assets in `docker/`, and package files in `packaging/`.
+
+## Build, Test, and Development Commands
+
+- `make build`: builds `bin/confd` with version and Git SHA ldflags.
+- `make test`: runs Go unit tests for all non-vendor packages.
+- `make lint`: runs `golangci-lint run ./...`.
+- `make integration`: runs all `test/integration/**/test.sh` scripts; backend services must be available.
+- `make mod`: runs `go mod tidy`.
+- `make clean`: removes build artifacts from `bin/`.
+- `make snapshot`: creates a local GoReleaser snapshot.
+
+After adding dependencies, run `go mod tidy` and `go mod vendor`; CI uses vendored modules.
+
+## Coding Style & Naming Conventions
+
+Use standard Go formatting (`gofmt`) and idioms. Package names should be short, lowercase, and descriptive. Exported identifiers require useful comments when they are part of package API. Prefer table-driven tests for multi-case behavior. Return errors instead of panicking, pass `context.Context` where cancellation or timeouts matter, and use `pkg/log` for structured logging. The configured linters are `errorlint` and `wrapcheck`, so wrap returned errors with context.
+
+## Testing Guidelines
+
+Use Go's standard `testing` package. Name tests `TestXxx`, benchmarks `BenchmarkXxx`, and keep unit tests next to the package under test. Run focused tests with `go test -run TestFunctionName ./pkg/template/`. Use `go test ./... -race -coverprofile=coverage.out -covermode=atomic` for broader validation. Integration tests should use the existing categories and shared expected-output checks.
+
+## Commit & Pull Request Guidelines
+
+Use Conventional Commits, matching project history: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, or `chore:`. Keep each PR focused on one logical change. Before opening a PR, run `make test` and `make lint`; run integration tests when backend behavior changes. PR descriptions should explain what changed, why it changed, how it was tested, linked issues, and any breaking changes. Always target `abtreece/confd`, not the abandoned upstream `kelseyhightower/confd`.
+
+## Agent-Specific Instructions
+
+Follow `CLAUDE.md` for repository-specific guidance. Do not add AI attribution or `Co-Authored-By` lines to commits. Preserve user changes in the worktree and avoid unrelated refactors.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [Docker documentation](docs/docker.md) for complete usage including Docker C
 
 ### Building from Source
 
-Go 1.25+ is required to build confd.
+Go 1.26.2 is required to build confd.
 
 ```bash
 git clone https://github.com/abtreece/confd.git

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,7 +1,7 @@
 # Multi-stage build Dockerfile for CI testing
 # Builds confd from source and produces a minimal runtime image
 
-FROM golang:1.26.2-alpine3.21 AS builder
+FROM golang:1.26.2-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,7 +1,7 @@
 # Multi-stage build Dockerfile for CI testing
 # Builds confd from source and produces a minimal runtime image
 
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.2-alpine3.21 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,7 +1,7 @@
 # Multi-stage build Dockerfile for CI testing
 # Builds confd from source and produces a minimal runtime image
 
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@ This guide covers setting up a development environment, building, testing, and d
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Go | 1.25+ | Build and test |
+| Go | 1.26.2 | Build and test |
 | golangci-lint | latest | Linting |
 | make | any | Build automation |
 
@@ -41,9 +41,9 @@ brew install go golangci-lint goreleaser
 
 **Linux:**
 ```bash
-# Go (check https://go.dev/dl/ for latest)
-wget https://go.dev/dl/go1.25.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.linux-amd64.tar.gz
+# Go 1.26.2
+wget https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # golangci-lint
@@ -69,7 +69,7 @@ This creates `bin/confd` with the Git SHA embedded via ldflags.
 
 ```bash
 ./bin/confd --version
-# Output: confd 0.40.0-rc.1 (Git SHA: abc1234, Go Version: go1.25)
+# Output: confd 0.40.0-rc.1 (Git SHA: abc1234, Go Version: go1.26.2)
 ```
 
 ### Project Structure

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -321,7 +321,7 @@ CMD ["consul", "--node", "http://consul:8500", "--watch"]
 ### Multi-stage Build from Source
 
 ```dockerfile
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 RUN apk add --no-cache git make
 WORKDIR /src

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -321,7 +321,7 @@ CMD ["consul", "--node", "http://consul:8500", "--watch"]
 ### Multi-stage Build from Source
 
 ```dockerfile
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.2-alpine3.21 AS builder
 
 RUN apk add --no-cache git make
 WORKDIR /src

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -321,7 +321,7 @@ CMD ["consul", "--node", "http://consul:8500", "--watch"]
 ### Multi-stage Build from Source
 
 ```dockerfile
-FROM golang:1.26.2-alpine3.21 AS builder
+FROM golang:1.26.2-alpine AS builder
 
 RUN apk add --no-cache git make
 WORKDIR /src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,7 +165,7 @@ docker build -t confd:local -f docker/Dockerfile.build .
 Include confd in your own Docker image using a multi-stage build:
 
 ```dockerfile
-FROM golang:1.25-alpine AS confd-builder
+FROM golang:1.26.2-alpine AS confd-builder
 
 RUN apk add --no-cache git
 WORKDIR /src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,7 +165,7 @@ docker build -t confd:local -f docker/Dockerfile.build .
 Include confd in your own Docker image using a multi-stage build:
 
 ```dockerfile
-FROM golang:1.26.2-alpine AS confd-builder
+FROM golang:1.26.2-alpine3.21 AS confd-builder
 
 RUN apk add --no-cache git
 WORKDIR /src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,7 +165,7 @@ docker build -t confd:local -f docker/Dockerfile.build .
 Include confd in your own Docker image using a multi-stage build:
 
 ```dockerfile
-FROM golang:1.26.2-alpine3.21 AS confd-builder
+FROM golang:1.26.2-alpine AS confd-builder
 
 RUN apk add --no-cache git
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/abtreece/confd
 
-go 1.26.2
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abtreece/confd
 
-go 1.26
+go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- Pin Go tooling, CI, Docker build references, and docs to Go 1.26.2
- Replace the AGENTS.md pointer with a contributor guide for this repository

## Validation
- go test ./...
- go test -mod=vendor ./pkg/... ./cmd/...