### PR TITLE
docs: clarify Go toolchain version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [Docker documentation](docs/docker.md) for complete usage including Docker C
 
 ### Building from Source
 
-Go 1.26.2 is required to build confd.
+Go 1.26.2 is required to build confd. The module uses `go 1.26` for language compatibility and `toolchain go1.26.2` to pin the expected patch-level toolchain.
 
 ```bash
 git clone https://github.com/abtreece/confd.git

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,8 @@ This guide covers setting up a development environment, building, testing, and d
 | golangci-lint | latest | Linting |
 | make | any | Build automation |
 
+The `go.mod` file keeps the language version at `go 1.26` and pins the expected patch-level compiler with `toolchain go1.26.2`. Keep `.tool-versions`, CI `setup-go` entries, Docker build images, and documentation aligned with that toolchain version.
+
 ### Optional Tools
 
 | Tool | Version | Purpose |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -147,6 +147,8 @@ RUN CONFD_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
 
 #### Building from Source
 
+Building from source requires the Go 1.26.2 toolchain. The module declares `go 1.26` for language compatibility and `toolchain go1.26.2` for the expected compiler patch version.
+
 ```bash
 make build
 make install


### PR DESCRIPTION
## Summary
- Clarify that Go 1.26.2 is the required build toolchain
- Explain the split between the go 1.26 language directive and toolchain go1.26.2
- Note that toolchain references should stay aligned across docs, CI, Docker, and .tool-versions

## Validation
- go test -mod=vendor ./pkg/... ./cmd/...