### PR TITLE
[codex] improve unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean lint test unit coverage race integration dep release
+.PHONY: build install clean lint test unit coverage race integration mod snapshot release
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "dev")
 GIT_SHA=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean lint test integration dep release
+.PHONY: build install clean lint test unit coverage race integration dep release
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo "dev")
 GIT_SHA=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
@@ -21,6 +21,18 @@ lint:
 test:
 	@echo "Running tests..."
 	@go test `go list ./... | grep -v vendor/`
+
+unit:
+	@echo "Running unit tests..."
+	@go test ./pkg/... ./cmd/...
+
+coverage:
+	@echo "Running unit tests with coverage..."
+	@go test -coverprofile=coverage.out ./pkg/... ./cmd/...
+
+race:
+	@echo "Running unit tests with race detector..."
+	@go test -race ./pkg/... ./cmd/...
 
 integration:
 	@echo "Running integration tests..."

--- a/pkg/backends/dynamodb/client_test.go
+++ b/pkg/backends/dynamodb/client_test.go
@@ -370,3 +370,65 @@ func TestHealthCheck_Error(t *testing.T) {
 		t.Errorf("HealthCheck() error = %v, want %v", err, expectedErr)
 	}
 }
+
+func TestHealthCheckDetailed_Success(t *testing.T) {
+	itemCount := int64(42)
+	mock := &mockDynamoDB{
+		describeTableFunc: func(ctx context.Context, input *dynamodb.DescribeTableInput, opts ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			if *input.TableName != "test-table" {
+				t.Fatalf("DescribeTable table = %q, want test-table", *input.TableName)
+			}
+			return &dynamodb.DescribeTableOutput{
+				Table: &types.TableDescription{
+					TableStatus: types.TableStatusActive,
+					ItemCount:   &itemCount,
+				},
+			}, nil
+		},
+	}
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed() unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = false, want true")
+	}
+	if result.Message != "DynamoDB backend is healthy" {
+		t.Fatalf("HealthCheckDetailed() Message = %q", result.Message)
+	}
+	if result.Details["table"] != "test-table" {
+		t.Fatalf("HealthCheckDetailed() table detail = %q", result.Details["table"])
+	}
+	if result.Details["table_status"] != string(types.TableStatusActive) {
+		t.Fatalf("HealthCheckDetailed() table_status = %q", result.Details["table_status"])
+	}
+	if result.Details["item_count"] != "42" {
+		t.Fatalf("HealthCheckDetailed() item_count = %q", result.Details["item_count"])
+	}
+}
+
+func TestHealthCheckDetailed_Error(t *testing.T) {
+	expectedErr := errors.New("describe failed")
+	mock := &mockDynamoDB{
+		describeTableFunc: func(ctx context.Context, input *dynamodb.DescribeTableInput, opts ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+			return nil, expectedErr
+		},
+	}
+	client := newTestClient(mock, "test-table")
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != expectedErr {
+		t.Fatalf("HealthCheckDetailed() error = %v, want %v", err, expectedErr)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = true, want false")
+	}
+	if result.Details["table"] != "test-table" {
+		t.Fatalf("HealthCheckDetailed() table detail = %q", result.Details["table"])
+	}
+	if result.Details["error"] != expectedErr.Error() {
+		t.Fatalf("HealthCheckDetailed() error detail = %q", result.Details["error"])
+	}
+}

--- a/pkg/backends/env/client_test.go
+++ b/pkg/backends/env/client_test.go
@@ -16,6 +16,32 @@ func TestNewEnvClient(t *testing.T) {
 	}
 }
 
+func TestHealthCheckDetailed(t *testing.T) {
+	t.Setenv("CONFD_ENV_HEALTH_TEST", "present")
+
+	client, err := NewEnvClient()
+	if err != nil {
+		t.Fatalf("NewEnvClient() error: %v", err)
+	}
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed() unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = false, want true")
+	}
+	if result.Message != "Environment backend is always healthy (no connectivity required)" {
+		t.Fatalf("HealthCheckDetailed() Message = %q", result.Message)
+	}
+	if result.Details["env_var_count"] == "" {
+		t.Fatalf("HealthCheckDetailed() missing env_var_count detail: %#v", result.Details)
+	}
+	if result.Details["note"] != "No network connectivity required for environment backend" {
+		t.Fatalf("HealthCheckDetailed() note = %q", result.Details["note"])
+	}
+}
+
 func TestGetValues(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/backends/secretsmanager/client_test.go
+++ b/pkg/backends/secretsmanager/client_test.go
@@ -457,3 +457,66 @@ func TestHealthCheck_Error(t *testing.T) {
 		t.Errorf("HealthCheck() error = %v, want %v", err, expectedErr)
 	}
 }
+
+func TestHealthCheckDetailed_Success(t *testing.T) {
+	token := "page-2"
+	callCount := 0
+	mock := &mockSecretsManager{
+		listSecretsFunc: func(ctx context.Context, input *secretsmanager.ListSecretsInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+			callCount++
+			if callCount == 1 {
+				return &secretsmanager.ListSecretsOutput{
+					SecretList: []types.SecretListEntry{
+						{Name: aws.String("a")},
+						{Name: aws.String("b")},
+					},
+					NextToken: &token,
+				}, nil
+			}
+			if input.NextToken == nil || *input.NextToken != token {
+				t.Fatalf("ListSecrets next token = %v, want %q", input.NextToken, token)
+			}
+			return &secretsmanager.ListSecretsOutput{
+				SecretList: []types.SecretListEntry{
+					{Name: aws.String("c")},
+				},
+			}, nil
+		},
+	}
+	client := newTestClient(mock, "", false)
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed() unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = false, want true")
+	}
+	if result.Message != "Secrets Manager backend is healthy" {
+		t.Fatalf("HealthCheckDetailed() Message = %q", result.Message)
+	}
+	if result.Details["secret_count"] != "3" {
+		t.Fatalf("HealthCheckDetailed() secret_count = %q", result.Details["secret_count"])
+	}
+}
+
+func TestHealthCheckDetailed_Error(t *testing.T) {
+	expectedErr := errors.New("secrets unavailable")
+	mock := &mockSecretsManager{
+		listSecretsFunc: func(ctx context.Context, input *secretsmanager.ListSecretsInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+			return nil, expectedErr
+		},
+	}
+	client := newTestClient(mock, "", false)
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != expectedErr {
+		t.Fatalf("HealthCheckDetailed() error = %v, want %v", err, expectedErr)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = true, want false")
+	}
+	if result.Details["error"] != expectedErr.Error() {
+		t.Fatalf("HealthCheckDetailed() error detail = %q", result.Details["error"])
+	}
+}

--- a/pkg/backends/ssm/client_test.go
+++ b/pkg/backends/ssm/client_test.go
@@ -13,9 +13,9 @@ import (
 
 // mockSSM implements the ssmAPI interface for testing
 type mockSSM struct {
-	getParameterFunc       func(ctx context.Context, input *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	getParameterFunc        func(ctx context.Context, input *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
 	getParametersByPathFunc func(ctx context.Context, input *ssm.GetParametersByPathInput, opts ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
-	nextToken              *string
+	nextToken               *string
 }
 
 func (m *mockSSM) GetParameter(ctx context.Context, input *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
@@ -372,5 +372,71 @@ func TestHealthCheck_Error(t *testing.T) {
 	}
 	if err != expectedErr {
 		t.Errorf("HealthCheck() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestHealthCheckDetailed_Success(t *testing.T) {
+	token := "page-2"
+	callCount := 0
+	mock := &mockSSM{
+		getParametersByPathFunc: func(ctx context.Context, input *ssm.GetParametersByPathInput, opts ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
+			callCount++
+			if *input.Path != "/" {
+				t.Fatalf("GetParametersByPath path = %q, want /", *input.Path)
+			}
+			if callCount == 1 {
+				return &ssm.GetParametersByPathOutput{
+					Parameters: []types.Parameter{
+						{Name: aws.String("/a"), Value: aws.String("1")},
+						{Name: aws.String("/b"), Value: aws.String("2")},
+					},
+					NextToken: &token,
+				}, nil
+			}
+			if input.NextToken == nil || *input.NextToken != token {
+				t.Fatalf("GetParametersByPath next token = %v, want %q", input.NextToken, token)
+			}
+			return &ssm.GetParametersByPathOutput{
+				Parameters: []types.Parameter{
+					{Name: aws.String("/c"), Value: aws.String("3")},
+				},
+			}, nil
+		},
+	}
+	client := newTestClient(mock)
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed() unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = false, want true")
+	}
+	if result.Message != "SSM backend is healthy" {
+		t.Fatalf("HealthCheckDetailed() Message = %q", result.Message)
+	}
+	if result.Details["parameter_count"] != "3" {
+		t.Fatalf("HealthCheckDetailed() parameter_count = %q", result.Details["parameter_count"])
+	}
+}
+
+func TestHealthCheckDetailed_Error(t *testing.T) {
+	expectedErr := errors.New("ssm unavailable")
+	mock := &mockSSM{
+		getParametersByPathFunc: func(ctx context.Context, input *ssm.GetParametersByPathInput, opts ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
+			return nil, expectedErr
+		},
+	}
+	client := newTestClient(mock)
+
+	result, err := client.HealthCheckDetailed(context.Background())
+	if err != expectedErr {
+		t.Fatalf("HealthCheckDetailed() error = %v, want %v", err, expectedErr)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheckDetailed() Healthy = true, want false")
+	}
+	if result.Details["error"] != expectedErr.Error() {
+		t.Fatalf("HealthCheckDetailed() error detail = %q", result.Details["error"])
 	}
 }

--- a/pkg/backends/types/noop_test.go
+++ b/pkg/backends/types/noop_test.go
@@ -2,7 +2,9 @@ package types_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/abtreece/confd/pkg/backends/types"
 )
@@ -40,5 +42,15 @@ func TestNoopCloser_Close(t *testing.T) {
 	var c types.NoopCloser
 	if err := c.Close(); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestDurationMillis_MarshalJSON(t *testing.T) {
+	got, err := json.Marshal(types.DurationMillis(1500 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if string(got) != "1500" {
+		t.Fatalf("Marshal = %s, want 1500", got)
 	}
 }

--- a/pkg/metrics/backend_test.go
+++ b/pkg/metrics/backend_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
+
+	"github.com/abtreece/confd/pkg/backends/types"
 )
 
 // mockStoreClient is a mock implementation of backends.StoreClient
@@ -13,6 +16,8 @@ type mockStoreClient struct {
 	watchResult     uint64
 	watchError      error
 	healthError     error
+	closeError      error
+	closeCalled     bool
 }
 
 func (m *mockStoreClient) GetValues(ctx context.Context, keys []string) (map[string]string, error) {
@@ -28,7 +33,18 @@ func (m *mockStoreClient) HealthCheck(ctx context.Context) error {
 }
 
 func (m *mockStoreClient) Close() error {
-	return nil
+	m.closeCalled = true
+	return m.closeError
+}
+
+type detailedMockStoreClient struct {
+	mockStoreClient
+	result *types.HealthResult
+	err    error
+}
+
+func (m *detailedMockStoreClient) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, error) {
+	return m.result, m.err
 }
 
 func TestWrapStoreClient_NoOpWhenMetricsDisabled(t *testing.T) {
@@ -180,6 +196,106 @@ func TestInstrumentedClient_HealthCheck_Error(t *testing.T) {
 
 	// Cleanup
 	Registry = nil
+}
+
+func TestInstrumentedClient_HealthCheckDetailed_SupportedSuccess(t *testing.T) {
+	Registry = nil
+	Initialize()
+	defer func() { Registry = nil }()
+
+	expected := &types.HealthResult{
+		Healthy:   true,
+		Message:   "ok",
+		Duration:  types.DurationMillis(10 * time.Millisecond),
+		CheckedAt: time.Now(),
+		Details:   map[string]string{"backend": "mock"},
+	}
+	mock := &detailedMockStoreClient{result: expected}
+	wrapped := WrapStoreClient(mock, "mock").(*InstrumentedClient)
+
+	result, err := wrapped.HealthCheckDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed returned error: %v", err)
+	}
+	if result != expected {
+		t.Fatalf("HealthCheckDetailed result = %#v, want %#v", result, expected)
+	}
+}
+
+func TestInstrumentedClient_HealthCheckDetailed_SupportedError(t *testing.T) {
+	Registry = nil
+	Initialize()
+	defer func() { Registry = nil }()
+
+	expectedErr := errors.New("detailed health failed")
+	mock := &detailedMockStoreClient{
+		result: &types.HealthResult{Healthy: false, Message: expectedErr.Error()},
+		err:    expectedErr,
+	}
+	wrapped := WrapStoreClient(mock, "mock").(*InstrumentedClient)
+
+	result, err := wrapped.HealthCheckDetailed(context.Background())
+	if err != expectedErr {
+		t.Fatalf("HealthCheckDetailed error = %v, want %v", err, expectedErr)
+	}
+	if result == nil || result.Healthy {
+		t.Fatalf("HealthCheckDetailed result = %#v, want unhealthy result", result)
+	}
+}
+
+func TestInstrumentedClient_HealthCheckDetailed_FallbackSuccess(t *testing.T) {
+	Registry = nil
+	Initialize()
+	defer func() { Registry = nil }()
+
+	mock := &mockStoreClient{}
+	wrapped := WrapStoreClient(mock, "mock").(*InstrumentedClient)
+
+	result, err := wrapped.HealthCheckDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("HealthCheckDetailed returned error: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheckDetailed Healthy = false, want true")
+	}
+	if result.Message != "Backend does not support detailed health checks" {
+		t.Fatalf("HealthCheckDetailed Message = %q", result.Message)
+	}
+}
+
+func TestInstrumentedClient_HealthCheckDetailed_FallbackError(t *testing.T) {
+	Registry = nil
+	Initialize()
+	defer func() { Registry = nil }()
+
+	expectedErr := errors.New("backend down")
+	mock := &mockStoreClient{healthError: expectedErr}
+	wrapped := WrapStoreClient(mock, "mock").(*InstrumentedClient)
+
+	result, err := wrapped.HealthCheckDetailed(context.Background())
+	if err != expectedErr {
+		t.Fatalf("HealthCheckDetailed error = %v, want %v", err, expectedErr)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheckDetailed Healthy = true, want false")
+	}
+	if result.Details["error"] != expectedErr.Error() {
+		t.Fatalf("HealthCheckDetailed error detail = %q", result.Details["error"])
+	}
+}
+
+func TestInstrumentedClient_Close(t *testing.T) {
+	expectedErr := errors.New("close failed")
+	mock := &mockStoreClient{closeError: expectedErr}
+	client := &InstrumentedClient{client: mock, backend: "mock"}
+
+	err := client.Close()
+	if err != expectedErr {
+		t.Fatalf("Close error = %v, want %v", err, expectedErr)
+	}
+	if !mock.closeCalled {
+		t.Fatal("Close did not call wrapped client")
+	}
 }
 
 func TestInstrumentedClient_RecordsMetrics(t *testing.T) {

--- a/pkg/metrics/health_test.go
+++ b/pkg/metrics/health_test.go
@@ -2,10 +2,14 @@ package metrics
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/abtreece/confd/pkg/backends/types"
 )
 
 // healthMockClient implements the StoreClient interface for health tests
@@ -27,6 +31,16 @@ func (m *healthMockClient) HealthCheck(ctx context.Context) error {
 
 func (m *healthMockClient) Close() error {
 	return nil
+}
+
+type detailedHealthMockClient struct {
+	healthMockClient
+	result *types.HealthResult
+	err    error
+}
+
+func (m *detailedHealthMockClient) HealthCheckDetailed(ctx context.Context) (*types.HealthResult, error) {
+	return m.result, m.err
 }
 
 func TestHealthHandler_ReturnsOK(t *testing.T) {
@@ -127,5 +141,129 @@ func TestHealthHandler_NilClient(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestReadyDetailedHandler_ReturnsOK_WhenDetailedBackendHealthy(t *testing.T) {
+	client := &detailedHealthMockClient{
+		result: &types.HealthResult{
+			Healthy:   true,
+			Message:   "backend healthy",
+			Duration:  types.DurationMillis(5 * time.Millisecond),
+			CheckedAt: time.Now(),
+			Details:   map[string]string{"version": "test"},
+		},
+	}
+	handler := ReadyDetailedHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/ready?verbose=true", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+
+	var result types.HealthResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if !result.Healthy || result.Message != "backend healthy" {
+		t.Fatalf("Response result = %#v", result)
+	}
+	if result.Details["version"] != "test" {
+		t.Fatalf("Response details = %#v", result.Details)
+	}
+}
+
+func TestReadyDetailedHandler_ReturnsUnavailable_WhenDetailedBackendUnhealthy(t *testing.T) {
+	expectedErr := errors.New("backend unavailable")
+	client := &detailedHealthMockClient{
+		result: &types.HealthResult{
+			Healthy:   false,
+			Message:   expectedErr.Error(),
+			CheckedAt: time.Now(),
+			Details:   map[string]string{"error": expectedErr.Error()},
+		},
+		err: expectedErr,
+	}
+	handler := ReadyDetailedHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/ready?verbose=true", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("Expected status %d, got %d", http.StatusServiceUnavailable, w.Code)
+	}
+
+	var result types.HealthResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if result.Healthy {
+		t.Fatalf("Response Healthy = true, want false")
+	}
+	if result.Details["error"] != expectedErr.Error() {
+		t.Fatalf("Response details = %#v", result.Details)
+	}
+}
+
+func TestReadyDetailedHandler_FallsBackToBasicHealthCheck(t *testing.T) {
+	client := &healthMockClient{}
+	handler := ReadyDetailedHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/ready?verbose=true", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var result types.HealthResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("Response Healthy = false, want true")
+	}
+	if result.Message != "Backend does not support detailed health checks" {
+		t.Fatalf("Response Message = %q", result.Message)
+	}
+}
+
+func TestReadyDetailedHandler_FallbackReportsBasicHealthError(t *testing.T) {
+	expectedErr := errors.New("connection refused")
+	client := &healthMockClient{healthError: expectedErr}
+	handler := ReadyDetailedHandler(client)
+
+	req := httptest.NewRequest(http.MethodGet, "/ready?verbose=true", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("Expected status %d, got %d", http.StatusServiceUnavailable, w.Code)
+	}
+
+	var result types.HealthResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if result.Healthy {
+		t.Fatalf("Response Healthy = true, want false")
+	}
+	if result.Message != expectedErr.Error() {
+		t.Fatalf("Response Message = %q", result.Message)
+	}
+	if result.Details["error"] != expectedErr.Error() {
+		t.Fatalf("Response details = %#v", result.Details)
 	}
 }

--- a/pkg/service/reload_test.go
+++ b/pkg/service/reload_test.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewReloadManager(t *testing.T) {
+	mgr := NewReloadManager()
+	if mgr == nil {
+		t.Fatal("NewReloadManager returned nil")
+	}
+	if mgr.subscribers == nil {
+		t.Fatal("subscribers was not initialized")
+	}
+	if len(mgr.subscribers) != 0 {
+		t.Fatalf("subscribers len = %d, want 0", len(mgr.subscribers))
+	}
+}
+
+func TestReloadManager_Subscribe(t *testing.T) {
+	mgr := NewReloadManager()
+
+	ch := mgr.Subscribe()
+	if ch == nil {
+		t.Fatal("Subscribe returned nil channel")
+	}
+	if cap(ch) != 1 {
+		t.Fatalf("subscriber channel cap = %d, want 1", cap(ch))
+	}
+	if len(mgr.subscribers) != 1 {
+		t.Fatalf("subscribers len = %d, want 1", len(mgr.subscribers))
+	}
+}
+
+func TestReloadManager_TriggerReloadNotifiesSubscribers(t *testing.T) {
+	mgr := NewReloadManager()
+	ch1 := mgr.Subscribe()
+	ch2 := mgr.Subscribe()
+
+	mgr.TriggerReload()
+
+	assertReloadSignal(t, ch1)
+	assertReloadSignal(t, ch2)
+}
+
+func TestReloadManager_TriggerReloadDoesNotBlockWhenSignalPending(t *testing.T) {
+	mgr := NewReloadManager()
+	ch := mgr.Subscribe()
+
+	mgr.TriggerReload()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		mgr.TriggerReload()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("TriggerReload blocked with a pending subscriber signal")
+	}
+
+	assertReloadSignal(t, ch)
+	select {
+	case <-ch:
+		t.Fatal("TriggerReload queued duplicate signal while one was pending")
+	default:
+	}
+}
+
+func TestReloadManager_TriggerReloadWithNoSubscribers(t *testing.T) {
+	mgr := NewReloadManager()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		mgr.TriggerReload()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("TriggerReload blocked with no subscribers")
+	}
+}
+
+func TestReloadManager_ConcurrentSubscribeAndTrigger(t *testing.T) {
+	mgr := NewReloadManager()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.Subscribe()
+		}()
+	}
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.TriggerReload()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent subscribe/trigger did not complete")
+	}
+}
+
+func assertReloadSignal(t *testing.T, ch chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reload signal")
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit unit, coverage, and race Make targets
- add reload manager tests for subscriber notification and non-blocking triggers
- expand detailed health coverage for metrics, env, types, DynamoDB, SSM, and Secrets Manager

## Testing
- go test ./pkg/...
- make unit
- go test -race ./pkg/service ./pkg/metrics ./pkg/backends/dynamodb ./pkg/backends/ssm ./pkg/backends/secretsmanager ./pkg/backends/types
- git diff --check

## Notes
Coverage across ./pkg/... improved from 76.0% to 78.7%.