### PR TITLE
[codex] fix config precedence resolution

### DIFF
--- a/cmd/confd/cli.go
+++ b/cmd/confd/cli.go
@@ -36,6 +36,8 @@ const (
 
 // CLI is the root command structure
 type CLI struct {
+	configSources *configSources
+
 	// Global flags
 	ConfDir       string `name:"confdir" help:"confd conf directory" default:"/etc/confd" env:"CONFD_CONFDIR"`
 	ConfigFile    string `name:"config-file" help:"confd config file" default:"/etc/confd/confd.toml" env:"CONFD_CONFIG_FILE"`
@@ -118,6 +120,13 @@ type CLI struct {
 	File           FileCmd           `cmd:"" name:"file" help:"Use file backend"`
 }
 
+// AfterApply captures which options came from CLI arguments or environment
+// variables before the config file is merged in run().
+func (c *CLI) AfterApply(ctx *kong.Context) error {
+	c.configSources = newConfigSources(ctx)
+	return nil
+}
+
 // VersionFlag is a custom flag type that prints version and exits
 type VersionFlag bool
 
@@ -156,9 +165,6 @@ type ConsulCmd struct {
 }
 
 func (c *ConsulCmd) Run(cli *CLI) error {
-	if len(c.Node) == 0 {
-		c.Node = []string{"127.0.0.1:8500"}
-	}
 	cfg := backends.Config{
 		Backend:      "consul",
 		BackendNodes: c.Node,
@@ -182,9 +188,6 @@ type EtcdCmd struct {
 }
 
 func (e *EtcdCmd) Run(cli *CLI) error {
-	if len(e.Node) == 0 {
-		e.Node = []string{"http://127.0.0.1:2379"}
-	}
 	cfg := backends.Config{
 		Backend:        "etcd",
 		BackendNodes:   e.Node,
@@ -215,9 +218,6 @@ type VaultCmd struct {
 }
 
 func (v *VaultCmd) Run(cli *CLI) error {
-	if len(v.Node) == 0 {
-		v.Node = []string{"http://127.0.0.1:8200"}
-	}
 	cfg := backends.Config{
 		Backend:      "vault",
 		BackendNodes: v.Node,
@@ -245,9 +245,6 @@ type RedisCmd struct {
 }
 
 func (r *RedisCmd) Run(cli *CLI) error {
-	if len(r.Node) == 0 {
-		r.Node = []string{"127.0.0.1:6379"}
-	}
 	cfg := backends.Config{
 		Backend:      "redis",
 		BackendNodes: r.Node,
@@ -266,9 +263,6 @@ type ZookeeperCmd struct {
 }
 
 func (z *ZookeeperCmd) Run(cli *CLI) error {
-	if len(z.Node) == 0 {
-		z.Node = []string{"127.0.0.1:2181"}
-	}
 	cfg := backends.Config{
 		Backend:      "zookeeper",
 		BackendNodes: z.Node,
@@ -386,6 +380,7 @@ func run(cli *CLI, backendCfg backends.Config) error {
 	if err := loadConfigFile(cli, &backendCfg); err != nil {
 		return err
 	}
+	applyBackendDefaults(&backendCfg)
 
 	// Process environment variables
 	processEnv(&backendCfg)
@@ -611,5 +606,23 @@ func run(cli *CLI, backendCfg backends.Config) error {
 		case <-doneChan:
 			return shutdown()
 		}
+	}
+}
+
+func applyBackendDefaults(cfg *backends.Config) {
+	if len(cfg.BackendNodes) > 0 {
+		return
+	}
+	switch cfg.Backend {
+	case "consul":
+		cfg.BackendNodes = []string{"127.0.0.1:8500"}
+	case "etcd":
+		cfg.BackendNodes = []string{"http://127.0.0.1:2379"}
+	case "vault":
+		cfg.BackendNodes = []string{"http://127.0.0.1:8200"}
+	case "redis":
+		cfg.BackendNodes = []string{"127.0.0.1:6379"}
+	case "zookeeper":
+		cfg.BackendNodes = []string{"127.0.0.1:2181"}
 	}
 }

--- a/cmd/confd/cli_test.go
+++ b/cmd/confd/cli_test.go
@@ -540,10 +540,15 @@ prefix = "/tomlprefix"
 
 	// CLI values should take precedence over TOML
 	cli := &CLI{
-		ConfDir:    "/cli/confd",    // Non-default CLI value
+		ConfDir:    "/cli/confd", // Non-default CLI value
 		ConfigFile: configPath,
-		Interval:   120,             // Non-default CLI value
-		Prefix:     "/cliprefix",    // CLI value
+		Interval:   120,          // Non-default CLI value
+		Prefix:     "/cliprefix", // CLI value
+		configSources: &configSources{cli: map[string]bool{
+			"confdir":  true,
+			"interval": true,
+			"prefix":   true,
+		}},
 	}
 	backendCfg := &backends.Config{}
 
@@ -903,13 +908,6 @@ func makeValidateCLI(t *testing.T) *CLI {
 }
 
 func TestBackendRunMethods_DefaultNodesWithCheckConfig(t *testing.T) {
-	assertDefaultNode := func(t *testing.T, nodes []string, expected string) {
-		t.Helper()
-		if len(nodes) != 1 || nodes[0] != expected {
-			t.Fatalf("unexpected default nodes: %v", nodes)
-		}
-	}
-
 	tests := []struct {
 		name string
 		run  func(*testing.T, *CLI) error
@@ -918,45 +916,35 @@ func TestBackendRunMethods_DefaultNodesWithCheckConfig(t *testing.T) {
 			name: "consul",
 			run: func(t *testing.T, cli *CLI) error {
 				cmd := &ConsulCmd{}
-				err := cmd.Run(cli)
-				assertDefaultNode(t, cmd.Node, "127.0.0.1:8500")
-				return err
+				return cmd.Run(cli)
 			},
 		},
 		{
 			name: "etcd",
 			run: func(t *testing.T, cli *CLI) error {
 				cmd := &EtcdCmd{}
-				err := cmd.Run(cli)
-				assertDefaultNode(t, cmd.Node, "http://127.0.0.1:2379")
-				return err
+				return cmd.Run(cli)
 			},
 		},
 		{
 			name: "vault",
 			run: func(t *testing.T, cli *CLI) error {
 				cmd := &VaultCmd{}
-				err := cmd.Run(cli)
-				assertDefaultNode(t, cmd.Node, "http://127.0.0.1:8200")
-				return err
+				return cmd.Run(cli)
 			},
 		},
 		{
 			name: "redis",
 			run: func(t *testing.T, cli *CLI) error {
 				cmd := &RedisCmd{}
-				err := cmd.Run(cli)
-				assertDefaultNode(t, cmd.Node, "127.0.0.1:6379")
-				return err
+				return cmd.Run(cli)
 			},
 		},
 		{
 			name: "zookeeper",
 			run: func(t *testing.T, cli *CLI) error {
 				cmd := &ZookeeperCmd{}
-				err := cmd.Run(cli)
-				assertDefaultNode(t, cmd.Node, "127.0.0.1:2181")
-				return err
+				return cmd.Run(cli)
 			},
 		},
 	}
@@ -966,6 +954,29 @@ func TestBackendRunMethods_DefaultNodesWithCheckConfig(t *testing.T) {
 			cli := makeCheckConfigCLI(t)
 			if err := tt.run(t, cli); err != nil {
 				t.Fatalf("Run() returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyBackendDefaults(t *testing.T) {
+	tests := []struct {
+		backend string
+		want    string
+	}{
+		{backend: "consul", want: "127.0.0.1:8500"},
+		{backend: "etcd", want: "http://127.0.0.1:2379"},
+		{backend: "vault", want: "http://127.0.0.1:8200"},
+		{backend: "redis", want: "127.0.0.1:6379"},
+		{backend: "zookeeper", want: "127.0.0.1:2181"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.backend, func(t *testing.T) {
+			cfg := &backends.Config{Backend: tt.backend}
+			applyBackendDefaults(cfg)
+			if len(cfg.BackendNodes) != 1 || cfg.BackendNodes[0] != tt.want {
+				t.Fatalf("BackendNodes = %v, want [%s]", cfg.BackendNodes, tt.want)
 			}
 		})
 	}

--- a/cmd/confd/config.go
+++ b/cmd/confd/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/abtreece/confd/pkg/backends"
 	"github.com/abtreece/confd/pkg/log"
+	"github.com/alecthomas/kong"
 )
 
 // TOMLConfig represents the structure of the confd TOML config file
@@ -50,9 +51,9 @@ type TOMLConfig struct {
 	Filter         string   `toml:"filter"`
 	Path           string   `toml:"path"`
 
-	ACMExportPrivateKey          bool   `toml:"acm_export_private_key"`
-	SecretsManagerVersionStage   string `toml:"secretsmanager_version_stage"`
-	SecretsManagerNoFlatten      bool   `toml:"secretsmanager_no_flatten"`
+	ACMExportPrivateKey        bool   `toml:"acm_export_private_key"`
+	SecretsManagerVersionStage string `toml:"secretsmanager_version_stage"`
+	SecretsManagerNoFlatten    bool   `toml:"secretsmanager_no_flatten"`
 
 	// Performance settings
 	TemplateCache *bool  `toml:"template_cache"` // Pointer to distinguish unset from false
@@ -78,6 +79,69 @@ type TOMLConfig struct {
 	MetricsAddr string `toml:"metrics_addr"`
 }
 
+type configSources struct {
+	cli map[string]bool
+	env map[string]bool
+}
+
+func newConfigSources(ctx *kong.Context) *configSources {
+	sources := &configSources{
+		cli: make(map[string]bool),
+		env: make(map[string]bool),
+	}
+	for _, path := range ctx.Path {
+		if path.Flag == nil {
+			continue
+		}
+		name := normalizeConfigName(path.Flag.Name)
+		if path.Resolved {
+			sources.env[name] = true
+			continue
+		}
+		sources.cli[name] = true
+	}
+	for _, flag := range ctx.Flags() {
+		for _, env := range flag.Envs {
+			if _, ok := os.LookupEnv(env); ok {
+				sources.env[normalizeConfigName(flag.Name)] = true
+				break
+			}
+		}
+	}
+	return sources
+}
+
+func normalizeConfigName(name string) string {
+	return strings.ReplaceAll(strings.ToLower(name), "-", "_")
+}
+
+func (s *configSources) isExplicit(name string) bool {
+	if s == nil {
+		return false
+	}
+	name = normalizeConfigName(name)
+	return s.cli[name] || s.env[name]
+}
+
+func tomlDefined(md toml.MetaData, names ...string) bool {
+	for _, name := range names {
+		if md.IsDefined(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldApplyTOML(s *configSources, md toml.MetaData, name string, aliases ...string) bool {
+	names := append([]string{name}, aliases...)
+	for _, candidate := range names {
+		if s.isExplicit(candidate) {
+			return false
+		}
+	}
+	return tomlDefined(md, names...)
+}
+
 // loadConfigFile loads the TOML config file and applies defaults to CLI and backend config
 func loadConfigFile(cli *CLI, backendCfg *backends.Config) error {
 	_, err := os.Stat(cli.ConfigFile)
@@ -93,209 +157,195 @@ func loadConfigFile(cli *CLI, backendCfg *backends.Config) error {
 	}
 
 	var tomlCfg TOMLConfig
-	if _, err = toml.Decode(string(configBytes), &tomlCfg); err != nil {
+	md, err := toml.Decode(string(configBytes), &tomlCfg)
+	if err != nil {
 		return err
 	}
 
+	sources := cli.configSources
+
 	// Apply TOML settings as defaults (CLI flags take precedence)
 	// Global settings
-	if cli.ConfDir == "/etc/confd" && tomlCfg.ConfDir != "" {
+	if shouldApplyTOML(sources, md, "confdir") && tomlCfg.ConfDir != "" {
 		cli.ConfDir = tomlCfg.ConfDir
 	}
-	if cli.Interval == 600 && tomlCfg.Interval != 0 {
+	if shouldApplyTOML(sources, md, "interval") && tomlCfg.Interval != 0 {
 		cli.Interval = tomlCfg.Interval
 	}
-	if !cli.Noop && tomlCfg.Noop {
-		cli.Noop = true
+	if shouldApplyTOML(sources, md, "noop") {
+		cli.Noop = tomlCfg.Noop
 	}
-	if cli.Prefix == "" && tomlCfg.Prefix != "" {
+	if shouldApplyTOML(sources, md, "prefix") && tomlCfg.Prefix != "" {
 		cli.Prefix = tomlCfg.Prefix
 	}
-	if !cli.SyncOnly && tomlCfg.SyncOnly {
-		cli.SyncOnly = true
+	if shouldApplyTOML(sources, md, "sync_only") {
+		cli.SyncOnly = tomlCfg.SyncOnly
 	}
-	if cli.LogLevel == "" && tomlCfg.LogLevel != "" {
+	if shouldApplyTOML(sources, md, "log_level", "log-level") && tomlCfg.LogLevel != "" {
 		cli.LogLevel = tomlCfg.LogLevel
 	}
-	if cli.LogFormat == "" && tomlCfg.LogFormat != "" {
+	if shouldApplyTOML(sources, md, "log_format", "log-format") && tomlCfg.LogFormat != "" {
 		cli.LogFormat = tomlCfg.LogFormat
 	}
-	if !cli.Watch && tomlCfg.Watch {
-		cli.Watch = true
+	if shouldApplyTOML(sources, md, "watch") {
+		cli.Watch = tomlCfg.Watch
 	}
-	if cli.FailureMode == "best-effort" && tomlCfg.FailureMode != "" {
+	if shouldApplyTOML(sources, md, "failure_mode") && tomlCfg.FailureMode != "" {
 		cli.FailureMode = tomlCfg.FailureMode
 	}
-	if !cli.KeepStageFile && tomlCfg.KeepStageFile {
-		cli.KeepStageFile = true
+	if shouldApplyTOML(sources, md, "keep_stage_file") {
+		cli.KeepStageFile = tomlCfg.KeepStageFile
 	}
-	// Template cache: TOML can only disable (CLI default is true)
-	if tomlCfg.TemplateCache != nil && !*tomlCfg.TemplateCache {
-		cli.TemplateCache = false
+	if shouldApplyTOML(sources, md, "template_cache") && tomlCfg.TemplateCache != nil {
+		cli.TemplateCache = *tomlCfg.TemplateCache
 	}
 	// Stat cache TTL
-	if tomlCfg.StatCacheTTL != "" {
+	if shouldApplyTOML(sources, md, "stat_cache_ttl") && tomlCfg.StatCacheTTL != "" {
 		d, err := time.ParseDuration(tomlCfg.StatCacheTTL)
 		if err != nil {
 			return fmt.Errorf("invalid stat_cache_ttl %q: %w (use Go duration format, e.g., \"1m\", \"5m\")", tomlCfg.StatCacheTTL, err)
 		}
-		if cli.StatCacheTTL == DefaultStatCacheTTL {
-			cli.StatCacheTTL = d
-		}
+		cli.StatCacheTTL = d
 	}
-	if cli.SRVDomain == "" && tomlCfg.SRVDomain != "" {
+	if shouldApplyTOML(sources, md, "srv_domain") && tomlCfg.SRVDomain != "" {
 		cli.SRVDomain = tomlCfg.SRVDomain
 	}
-	if cli.SRVRecord == "" && tomlCfg.SRVRecord != "" {
+	if shouldApplyTOML(sources, md, "srv_record") && tomlCfg.SRVRecord != "" {
 		cli.SRVRecord = tomlCfg.SRVRecord
 	}
-	if cli.MetricsAddr == "" && tomlCfg.MetricsAddr != "" {
+	if shouldApplyTOML(sources, md, "metrics_addr") && tomlCfg.MetricsAddr != "" {
 		cli.MetricsAddr = tomlCfg.MetricsAddr
 	}
 
 	// Backend settings (only apply if not already set via CLI)
-	if len(backendCfg.BackendNodes) == 0 && len(tomlCfg.Nodes) > 0 {
+	if shouldApplyTOML(sources, md, "nodes", "node") && len(tomlCfg.Nodes) > 0 {
 		backendCfg.BackendNodes = tomlCfg.Nodes
 	}
-	if backendCfg.AuthToken == "" && tomlCfg.AuthToken != "" {
+	if shouldApplyTOML(sources, md, "auth_token") && tomlCfg.AuthToken != "" {
 		backendCfg.AuthToken = tomlCfg.AuthToken
 	}
-	if backendCfg.AuthType == "" && tomlCfg.AuthType != "" {
+	if shouldApplyTOML(sources, md, "auth_type") && tomlCfg.AuthType != "" {
 		backendCfg.AuthType = tomlCfg.AuthType
 	}
-	if !backendCfg.BasicAuth && tomlCfg.BasicAuth {
-		backendCfg.BasicAuth = true
+	if shouldApplyTOML(sources, md, "basic_auth") {
+		backendCfg.BasicAuth = tomlCfg.BasicAuth
 	}
-	if backendCfg.ClientCaKeys == "" && tomlCfg.ClientCaKeys != "" {
+	if shouldApplyTOML(sources, md, "client_cakeys", "client_ca_keys") && tomlCfg.ClientCaKeys != "" {
 		backendCfg.ClientCaKeys = tomlCfg.ClientCaKeys
 	}
-	if backendCfg.ClientCert == "" && tomlCfg.ClientCert != "" {
+	if shouldApplyTOML(sources, md, "client_cert") && tomlCfg.ClientCert != "" {
 		backendCfg.ClientCert = tomlCfg.ClientCert
 	}
-	if backendCfg.ClientKey == "" && tomlCfg.ClientKey != "" {
+	if shouldApplyTOML(sources, md, "client_key") && tomlCfg.ClientKey != "" {
 		backendCfg.ClientKey = tomlCfg.ClientKey
 	}
-	if !backendCfg.ClientInsecure && tomlCfg.ClientInsecure {
-		backendCfg.ClientInsecure = true
+	if shouldApplyTOML(sources, md, "client_insecure") {
+		backendCfg.ClientInsecure = tomlCfg.ClientInsecure
 	}
-	if backendCfg.Password == "" && tomlCfg.Password != "" {
+	if shouldApplyTOML(sources, md, "password") && tomlCfg.Password != "" {
 		backendCfg.Password = tomlCfg.Password
 	}
-	if backendCfg.Scheme == "" && tomlCfg.Scheme != "" {
+	if shouldApplyTOML(sources, md, "scheme") && tomlCfg.Scheme != "" {
 		backendCfg.Scheme = tomlCfg.Scheme
 	}
-	if backendCfg.Table == "" && tomlCfg.Table != "" {
+	if shouldApplyTOML(sources, md, "table") && tomlCfg.Table != "" {
 		backendCfg.Table = tomlCfg.Table
 	}
-	if backendCfg.Separator == "" && tomlCfg.Separator != "" {
+	if shouldApplyTOML(sources, md, "separator") && tomlCfg.Separator != "" {
 		backendCfg.Separator = tomlCfg.Separator
 	}
-	if backendCfg.Username == "" && tomlCfg.Username != "" {
+	if shouldApplyTOML(sources, md, "username") && tomlCfg.Username != "" {
 		backendCfg.Username = tomlCfg.Username
 	}
-	if backendCfg.AppID == "" && tomlCfg.AppID != "" {
+	if shouldApplyTOML(sources, md, "app_id") && tomlCfg.AppID != "" {
 		backendCfg.AppID = tomlCfg.AppID
 	}
-	if backendCfg.UserID == "" && tomlCfg.UserID != "" {
+	if shouldApplyTOML(sources, md, "user_id") && tomlCfg.UserID != "" {
 		backendCfg.UserID = tomlCfg.UserID
 	}
-	if backendCfg.RoleID == "" && tomlCfg.RoleID != "" {
+	if shouldApplyTOML(sources, md, "role_id") && tomlCfg.RoleID != "" {
 		backendCfg.RoleID = tomlCfg.RoleID
 	}
-	if backendCfg.SecretID == "" && tomlCfg.SecretID != "" {
+	if shouldApplyTOML(sources, md, "secret_id") && tomlCfg.SecretID != "" {
 		backendCfg.SecretID = tomlCfg.SecretID
 	}
-	if len(backendCfg.YAMLFile) == 0 && len(tomlCfg.File) > 0 {
+	if shouldApplyTOML(sources, md, "file") && len(tomlCfg.File) > 0 {
 		backendCfg.YAMLFile = tomlCfg.File
 	}
-	if backendCfg.Filter == "" && tomlCfg.Filter != "" {
+	if shouldApplyTOML(sources, md, "filter") && tomlCfg.Filter != "" {
 		backendCfg.Filter = tomlCfg.Filter
 	}
-	if backendCfg.Path == "" && tomlCfg.Path != "" {
+	if shouldApplyTOML(sources, md, "path") && tomlCfg.Path != "" {
 		backendCfg.Path = tomlCfg.Path
 	}
-	if !backendCfg.ACMExportPrivateKey && tomlCfg.ACMExportPrivateKey {
-		backendCfg.ACMExportPrivateKey = true
+	if shouldApplyTOML(sources, md, "acm_export_private_key") {
+		backendCfg.ACMExportPrivateKey = tomlCfg.ACMExportPrivateKey
 	}
-	if backendCfg.SecretsManagerVersionStage == "" && tomlCfg.SecretsManagerVersionStage != "" {
+	if shouldApplyTOML(sources, md, "secretsmanager_version_stage") && tomlCfg.SecretsManagerVersionStage != "" {
 		backendCfg.SecretsManagerVersionStage = tomlCfg.SecretsManagerVersionStage
 	}
-	if !backendCfg.SecretsManagerNoFlatten && tomlCfg.SecretsManagerNoFlatten {
-		backendCfg.SecretsManagerNoFlatten = true
+	if shouldApplyTOML(sources, md, "secretsmanager_no_flatten") {
+		backendCfg.SecretsManagerNoFlatten = tomlCfg.SecretsManagerNoFlatten
 	}
 
 	// Connection timeout settings (apply to CLI if default, then to backend config)
-	if tomlCfg.DialTimeout != "" {
+	if shouldApplyTOML(sources, md, "dial_timeout") && tomlCfg.DialTimeout != "" {
 		d, err := time.ParseDuration(tomlCfg.DialTimeout)
 		if err != nil {
 			return fmt.Errorf("invalid dial_timeout %q: %w (use Go duration format, e.g., \"5s\", \"30s\")", tomlCfg.DialTimeout, err)
 		}
-		if cli.DialTimeout == DefaultDialTimeout {
-			cli.DialTimeout = d
-		}
+		cli.DialTimeout = d
 	}
-	if tomlCfg.ReadTimeout != "" {
+	if shouldApplyTOML(sources, md, "read_timeout") && tomlCfg.ReadTimeout != "" {
 		d, err := time.ParseDuration(tomlCfg.ReadTimeout)
 		if err != nil {
 			return fmt.Errorf("invalid read_timeout %q: %w (use Go duration format, e.g., \"1s\", \"5s\")", tomlCfg.ReadTimeout, err)
 		}
-		if cli.ReadTimeout == DefaultReadTimeout {
-			cli.ReadTimeout = d
-		}
+		cli.ReadTimeout = d
 	}
-	if tomlCfg.WriteTimeout != "" {
+	if shouldApplyTOML(sources, md, "write_timeout") && tomlCfg.WriteTimeout != "" {
 		d, err := time.ParseDuration(tomlCfg.WriteTimeout)
 		if err != nil {
 			return fmt.Errorf("invalid write_timeout %q: %w (use Go duration format, e.g., \"1s\", \"5s\")", tomlCfg.WriteTimeout, err)
 		}
-		if cli.WriteTimeout == DefaultWriteTimeout {
-			cli.WriteTimeout = d
-		}
+		cli.WriteTimeout = d
 	}
 
 	// Retry configuration (apply to CLI if default, then to backend config)
-	if tomlCfg.RetryMaxAttempts != 0 && cli.RetryMaxAttempts == DefaultRetryMaxAttempts {
+	if shouldApplyTOML(sources, md, "retry_max_attempts") && tomlCfg.RetryMaxAttempts != 0 {
 		cli.RetryMaxAttempts = tomlCfg.RetryMaxAttempts
 	}
-	if tomlCfg.RetryBaseDelay != "" {
+	if shouldApplyTOML(sources, md, "retry_base_delay") && tomlCfg.RetryBaseDelay != "" {
 		d, err := time.ParseDuration(tomlCfg.RetryBaseDelay)
 		if err != nil {
 			return fmt.Errorf("invalid retry_base_delay %q: %w (use Go duration format, e.g., \"100ms\", \"1s\")", tomlCfg.RetryBaseDelay, err)
 		}
-		if cli.RetryBaseDelay == DefaultRetryBaseDelay {
-			cli.RetryBaseDelay = d
-		}
+		cli.RetryBaseDelay = d
 	}
-	if tomlCfg.RetryMaxDelay != "" {
+	if shouldApplyTOML(sources, md, "retry_max_delay") && tomlCfg.RetryMaxDelay != "" {
 		d, err := time.ParseDuration(tomlCfg.RetryMaxDelay)
 		if err != nil {
 			return fmt.Errorf("invalid retry_max_delay %q: %w (use Go duration format, e.g., \"5s\", \"30s\")", tomlCfg.RetryMaxDelay, err)
 		}
-		if cli.RetryMaxDelay == DefaultRetryMaxDelay {
-			cli.RetryMaxDelay = d
-		}
+		cli.RetryMaxDelay = d
 	}
 
 	// Watch mode timeouts
-	if tomlCfg.WatchErrorBackoff != "" {
+	if shouldApplyTOML(sources, md, "watch_error_backoff") && tomlCfg.WatchErrorBackoff != "" {
 		d, err := time.ParseDuration(tomlCfg.WatchErrorBackoff)
 		if err != nil {
 			return fmt.Errorf("invalid watch_error_backoff %q: %w (use Go duration format, e.g., \"2s\", \"5s\")", tomlCfg.WatchErrorBackoff, err)
 		}
-		if cli.WatchErrorBackoff == DefaultWatchErrorBackoff {
-			cli.WatchErrorBackoff = d
-		}
+		cli.WatchErrorBackoff = d
 	}
 
 	// Preflight timeout
-	if tomlCfg.PreflightTimeout != "" {
+	if shouldApplyTOML(sources, md, "preflight_timeout") && tomlCfg.PreflightTimeout != "" {
 		d, err := time.ParseDuration(tomlCfg.PreflightTimeout)
 		if err != nil {
 			return fmt.Errorf("invalid preflight_timeout %q: %w (use Go duration format, e.g., \"10s\", \"30s\")", tomlCfg.PreflightTimeout, err)
 		}
-		if cli.PreflightTimeout == DefaultPreflightTimeout {
-			cli.PreflightTimeout = d
-		}
+		cli.PreflightTimeout = d
 	}
 
 	return nil

--- a/cmd/confd/config_test.go
+++ b/cmd/confd/config_test.go
@@ -5,16 +5,17 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/abtreece/confd/pkg/backends"
 )
 
 func TestLoadConfigFile_InvalidDurations(t *testing.T) {
 	tests := []struct {
-		name        string
-		configTOML  string
-		wantErrMsg  string
-		wantHint    string
+		name       string
+		configTOML string
+		wantErrMsg string
+		wantHint   string
 	}{
 		{
 			name: "invalid stat_cache_ttl",
@@ -219,4 +220,132 @@ func TestLoadConfigFile_MissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error for missing config file: %v", err)
 	}
+}
+
+func TestLoadConfigFile_ExplicitDefaultSourcesOverrideTOML(t *testing.T) {
+	clearCONFDEnvVars(t)
+
+	configFile := writeConfigFile(t, `
+interval = 300
+failure_mode = "fail-fast"
+dial_timeout = "10s"
+`)
+
+	tests := []struct {
+		name  string
+		env   map[string]string
+		args  []string
+		check func(*testing.T, *CLI)
+	}{
+		{
+			name: "env interval default beats toml",
+			env:  map[string]string{"CONFD_INTERVAL": "600"},
+			args: []string{"--config-file", configFile, "env"},
+			check: func(t *testing.T, cli *CLI) {
+				t.Helper()
+				if cli.Interval != 600 {
+					t.Fatalf("Interval = %d, want explicit env default 600", cli.Interval)
+				}
+			},
+		},
+		{
+			name: "cli interval default beats toml",
+			args: []string{"--config-file", configFile, "--interval", "600", "env"},
+			check: func(t *testing.T, cli *CLI) {
+				t.Helper()
+				if cli.Interval != 600 {
+					t.Fatalf("Interval = %d, want explicit CLI default 600", cli.Interval)
+				}
+			},
+		},
+		{
+			name: "env failure mode default beats toml",
+			env:  map[string]string{"CONFD_FAILURE_MODE": "best-effort"},
+			args: []string{"--config-file", configFile, "env"},
+			check: func(t *testing.T, cli *CLI) {
+				t.Helper()
+				if cli.FailureMode != "best-effort" {
+					t.Fatalf("FailureMode = %q, want explicit env default best-effort", cli.FailureMode)
+				}
+			},
+		},
+		{
+			name: "env duration default beats toml",
+			env:  map[string]string{"CONFD_DIAL_TIMEOUT": "5s"},
+			args: []string{"--config-file", configFile, "env"},
+			check: func(t *testing.T, cli *CLI) {
+				t.Helper()
+				if cli.DialTimeout != 5*time.Second {
+					t.Fatalf("DialTimeout = %v, want explicit env default 5s", cli.DialTimeout)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearCONFDEnvVars(t)
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			cli, _ := parseCLI(t, tt.args)
+			backendCfg := &backends.Config{}
+
+			if err := loadConfigFile(cli, backendCfg); err != nil {
+				t.Fatalf("loadConfigFile failed: %v", err)
+			}
+			tt.check(t, cli)
+		})
+	}
+}
+
+func TestLoadConfigFile_BackendPrecedenceWithCommandDefaults(t *testing.T) {
+	clearCONFDEnvVars(t)
+
+	configFile := writeConfigFile(t, `
+nodes = ["toml:8500"]
+scheme = "https"
+`)
+
+	cli, _ := parseCLI(t, []string{"--config-file", configFile, "consul"})
+	backendCfg := &backends.Config{
+		Backend:      "consul",
+		BackendNodes: cli.Consul.Node,
+		Scheme:       cli.Consul.Scheme,
+	}
+	if err := loadConfigFile(cli, backendCfg); err != nil {
+		t.Fatalf("loadConfigFile failed: %v", err)
+	}
+	if got := []string(backendCfg.BackendNodes); len(got) != 1 || got[0] != "toml:8500" {
+		t.Fatalf("BackendNodes = %v, want TOML nodes", backendCfg.BackendNodes)
+	}
+	if backendCfg.Scheme != "https" {
+		t.Fatalf("Scheme = %q, want TOML scheme", backendCfg.Scheme)
+	}
+
+	cli, _ = parseCLI(t, []string{"--config-file", configFile, "consul", "--node", "cli:8500", "--scheme", "http"})
+	backendCfg = &backends.Config{
+		Backend:      "consul",
+		BackendNodes: cli.Consul.Node,
+		Scheme:       cli.Consul.Scheme,
+	}
+	if err := loadConfigFile(cli, backendCfg); err != nil {
+		t.Fatalf("loadConfigFile failed: %v", err)
+	}
+	if got := []string(backendCfg.BackendNodes); len(got) != 1 || got[0] != "cli:8500" {
+		t.Fatalf("BackendNodes = %v, want CLI nodes", backendCfg.BackendNodes)
+	}
+	if backendCfg.Scheme != "http" {
+		t.Fatalf("Scheme = %q, want CLI scheme", backendCfg.Scheme)
+	}
+}
+
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+
+	configFile := filepath.Join(t.TempDir(), "confd.toml")
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	return configFile
 }

--- a/test/e2e/concurrency/concurrent_test.go
+++ b/test/e2e/concurrency/concurrent_test.go
@@ -108,11 +108,11 @@ dest = "%s"
 keys = ["/key"]
 `, destPath))
 
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-			defer cancel()
-
 			confd := operations.NewConfdBinary(t)
 			confd.SetEnv("KEY", fmt.Sprintf("value-from-instance-%d", instanceID))
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
 
 			err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
 			if err != nil {
@@ -255,12 +255,12 @@ dest = "%s"
 keys = ["/database"]
 `, destPath3))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	confd := operations.NewConfdBinary(t)
 	confd.SetEnv("DATABASE_HOST", "db.example.com")
 	confd.SetEnv("DATABASE_PORT", "5432")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
 	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
 	if err != nil {
@@ -339,10 +339,10 @@ key: {{ getv "/key" }}
 		// Small delay to ensure mtime changes (some filesystems have 1s resolution)
 		time.Sleep(100 * time.Millisecond)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-
 		confd := operations.NewConfdBinary(t)
 		confd.SetEnv("KEY", fmt.Sprintf("value-v%d", version))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 
 		err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
 		if err != nil {
@@ -395,11 +395,11 @@ dest = "%s"
 keys = ["/prefix"]
 `, destPath))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-
 	confd := operations.NewConfdBinary(t)
 	confd.SetEnv("PREFIX", "test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
 
 	err := confd.Start(ctx, "env", "--onetime", "--confdir", env.ConfDir, "--log-level", "error")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Track whether config options came from CLI arguments or environment variables before merging TOML
- Apply TOML only when the option was not explicitly supplied by CLI/env
- Move backend node defaults after TOML resolution so config-file nodes can apply
- Add precedence regression coverage for explicit default-valued CLI/env settings

## Why
Fixes #601. The old merge logic compared parsed values against hard-coded defaults, so an explicit default-valued CLI/env setting could be treated as unset and overwritten by TOML.

## Validation
- go test ./cmd/confd
- go test ./...