### PR TITLE
chore: bump Go toolchain to 1.26.3

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run go test for coverage
         run: go test -vet=off ./... -race -coverprofile=coverage.out -covermode=atomic

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run unit tests
         run: go test -mod=vendor ./pkg/... ./cmd/...

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run E2E Tests
         run: go test -v -tags=e2e -timeout 15m ./test/e2e/...

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build and Install
         run: |
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build and Install
         run: |
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build and Install
         run: |
@@ -235,7 +235,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build and Install
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.2
+golang 1.26.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/dynamodb from 1.55.0 to 1.57.3 (#596)
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/acm from 1.38.1 to 1.38.3 (#597)
 * chore: bump Go from 1.25 to 1.26 in build infra (Dockerfile, workflows)
-* chore: bump Go toolchain to 1.26.3 to patch stdlib CVEs (CVE-2026-33811, 33814, 39820, 39836, 42499)
+* chore: bump Go toolchain to 1.26.3 to patch stdlib CVEs (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499)
 
 ### v0.41.1 (2026-04-22)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/dynamodb from 1.55.0 to 1.57.3 (#596)
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/acm from 1.38.1 to 1.38.3 (#597)
 * chore: bump Go from 1.25 to 1.26 in build infra (Dockerfile, workflows)
+* chore: bump Go toolchain to 1.26.3 to patch stdlib CVEs (CVE-2026-33811, 33814, 39820, 39836, 42499)
 
 ### v0.41.1 (2026-04-22)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [Docker documentation](docs/docker.md) for complete usage including Docker C
 
 ### Building from Source
 
-Go 1.26.2 is required to build confd. The module uses `go 1.26` for language compatibility and `toolchain go1.26.2` to pin the expected patch-level toolchain.
+Go 1.26.3 is required to build confd. The module uses `go 1.26` for language compatibility and `toolchain go1.26.3` to pin the expected patch-level toolchain.
 
 ```bash
 git clone https://github.com/abtreece/confd.git

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,7 +1,7 @@
 # Multi-stage build Dockerfile for CI testing
 # Builds confd from source and produces a minimal runtime image
 
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,11 +20,11 @@ This guide covers setting up a development environment, building, testing, and d
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Go | 1.26.2 | Build and test |
+| Go | 1.26.3 | Build and test |
 | golangci-lint | latest | Linting |
 | make | any | Build automation |
 
-The `go.mod` file keeps the language version at `go 1.26` and pins the expected patch-level compiler with `toolchain go1.26.2`. Keep `.tool-versions`, CI `setup-go` entries, Docker build images, and documentation aligned with that toolchain version.
+The `go.mod` file keeps the language version at `go 1.26` and pins the expected patch-level compiler with `toolchain go1.26.3`. Keep `.tool-versions`, CI `setup-go` entries, Docker build images, and documentation aligned with that toolchain version.
 
 ### Optional Tools
 
@@ -43,9 +43,9 @@ brew install go golangci-lint goreleaser
 
 **Linux:**
 ```bash
-# Go 1.26.2
-wget https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+# Go 1.26.3
+wget https://go.dev/dl/go1.26.3.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.3.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
 # golangci-lint
@@ -71,7 +71,7 @@ This creates `bin/confd` with the Git SHA embedded via ldflags.
 
 ```bash
 ./bin/confd --version
-# Output: confd 0.40.0-rc.1 (Git SHA: abc1234, Go Version: go1.26.2)
+# Output: confd 0.40.0-rc.1 (Git SHA: abc1234, Go Version: go1.26.3)
 ```
 
 ### Project Structure

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -321,7 +321,7 @@ CMD ["consul", "--node", "http://consul:8500", "--watch"]
 ### Multi-stage Build from Source
 
 ```dockerfile
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 RUN apk add --no-cache git make
 WORKDIR /src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -147,7 +147,7 @@ RUN CONFD_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
 
 #### Building from Source
 
-Building from source requires the Go 1.26.2 toolchain. The module declares `go 1.26` for language compatibility and `toolchain go1.26.2` for the expected compiler patch version.
+Building from source requires the Go 1.26.3 toolchain. The module declares `go 1.26` for language compatibility and `toolchain go1.26.3` for the expected compiler patch version.
 
 ```bash
 make build
@@ -167,7 +167,7 @@ docker build -t confd:local -f docker/Dockerfile.build .
 Include confd in your own Docker image using a multi-stage build:
 
 ```dockerfile
-FROM golang:1.26.2-alpine AS confd-builder
+FROM golang:1.26.3-alpine AS confd-builder
 
 RUN apk add --no-cache git
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/abtreece/confd
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.26.2 → 1.26.3 to patch 5 HIGH stdlib CVEs that Trivy is currently flagging on every dependabot PR's `security-scan` job:

- CVE-2026-33811 — `LookupCNAME` (cgo resolver) on long CNAME
- CVE-2026-33814 — HTTP/2 SETTINGS frame infinite loop
- CVE-2026-39820 — `mail.ParseAddress` / `ParseAddressList`
- CVE-2026-39836 — Windows `Dial`/`LookupPort` NUL byte panic
- CVE-2026-42499 — `consumePhrase` DoS

All dependabot PRs (#613, #614, #616) have been failing security-scan against the v1.26.2 stdlib even though their dep bumps are otherwise clean. This bump unblocks them.

### Files updated
- `go.mod` (`toolchain go1.26.3`)
- `.tool-versions`
- `docker/Dockerfile.build`
- 5 GitHub Actions workflows (`codecov`, `release`, `cross-platform`, `e2e-tests`, `integration-tests`)
- Docs: `README.md`, `docs/development.md`, `docs/docker.md`, `docs/installation.md`
- `CHANGELOG`

## Test plan

- [ ] CI green across all workflows (build, tests, integration, docker security-scan)
- [ ] `confd --version` from built binary reports `go1.26.3`