### PR TITLE
docs: update CHANGELOG for merged dep bumps and Go 1.26.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,9 @@
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/dynamodb from 1.55.0 to 1.57.3 (#596)
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/acm from 1.38.1 to 1.38.3 (#597)
 * chore: bump Go from 1.25 to 1.26 in build infra (Dockerfile, workflows)
-* chore: bump Go toolchain to 1.26.3 to patch stdlib CVEs (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499)
+* chore: bump Go toolchain to 1.26.3 to patch stdlib CVEs (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499) (#617)
+* chore(deps): bump go.etcd.io/etcd/client/v3 from 3.6.10 to 3.6.11 (#614)
+* chore(deps): bump github.com/redis/go-redis/v9 from 9.18.0 to 9.19.0 (#613)
 
 ### v0.41.1 (2026-04-22)
 


### PR DESCRIPTION
## Summary

Adds CHANGELOG entries (with PR references) for the dependency work that landed today:

- #617 — Go toolchain bump to 1.26.3 (patches 5 HIGH stdlib CVEs)
- #614 — etcd `client/v3` 3.6.10 → 3.6.11 (transitively pulled `api/v3` 3.6.11, superseding #616)
- #613 — redis/go-redis 9.18.0 → 9.19.0

Also appends `(#617)` to the existing Go toolchain entry that was added in that PR without a reference.

## Test plan

- [ ] No code changes; docs only