### PR TITLE
docs: backfill CHANGELOG with missed merged PRs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,17 @@
 ### [Unreleased]
 
+* fix: match CHANGELOG headers with date suffix in release workflow (#590)
 * chore(deps): bump github.com/hashicorp/consul/api from 1.33.7 to 1.34.2 (#591)
 * chore(deps): bump github.com/hashicorp/vault/api from 1.22.0 to 1.23.0 (#593)
 * chore(deps): bump github.com/fsnotify/fsnotify from 1.9.0 to 1.10.1 (#595)
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/dynamodb from 1.55.0 to 1.57.3 (#596)
 * chore(deps): bump github.com/aws/aws-sdk-go-v2/service/acm from 1.38.1 to 1.38.3 (#597)
 * chore: bump Go from 1.25 to 1.26 in build infra (Dockerfile, workflows)
+* chore: consolidate Go version pins across the repo (#598)
+* docs: clarify Go toolchain version guidance (#599)
+* test: improve unit test coverage (#600)
+* fix: config precedence resolution (#609)
+* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.32.16 to 1.32.17 (#612)
 * chore: bump Go toolchain to 1.26.3 to patch stdlib CVEs (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499) (#617)
 * chore(deps): bump go.etcd.io/etcd/client/v3 from 3.6.10 to 3.6.11 (#614)
 * chore(deps): bump github.com/redis/go-redis/v9 from 9.18.0 to 9.19.0 (#613)


### PR DESCRIPTION
## Summary

Audit of merged PRs since v0.41.1 (2026-04-22) found six entries missing from the \`[Unreleased]\` section. Backfilling them now:

| PR | Entry |
|----|-------|
| #590 | fix: match CHANGELOG headers with date suffix in release workflow |
| #598 | chore: consolidate Go version pins across the repo |
| #599 | docs: clarify Go toolchain version guidance |
| #600 | test: improve unit test coverage |
| #609 | fix: config precedence resolution |
| #612 | chore(deps): bump aws-sdk-go-v2/config 1.32.16 → 1.32.17 |

The existing \`chore: bump Go from 1.25 to 1.26 in build infra\` line is left as-is — that work landed as a direct push (commit \`5827a6ba\`, no PR), with #598 and #599 as follow-ups.

## Test plan

- [ ] Docs only, no code changes