### PR TITLE
docs: refresh post-v0.41.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.40.0-rc.1)'
+        description: 'Tag to release (e.g., vX.Y.Z or vX.Y.Z-rc.1)'
         required: true
         type: string
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,21 +421,21 @@ See [docs/release-checklist.md](docs/release-checklist.md) for the complete rele
 
 The version is automatically injected from the git tag at build time via goreleaser's ldflags. No manual version file updates are required.
 
-- **Release builds**: Version comes from git tag (e.g., tag `v0.40.0` → version `0.40.0`)
-- **Local builds**: Version comes from `git describe` (e.g., `0.40.0-rc.2-5-gabcdef-dirty`)
+- **Release builds**: Version comes from git tag (e.g., tag `vX.Y.Z` → version `X.Y.Z`)
+- **Local builds**: Version comes from `git describe` (e.g., `X.Y.Z-rc.2-5-gabcdef-dirty`)
 - **Development**: Shows `dev` if no tags exist
 
 ### Release Workflow
 
 ```bash
-# 1. Update CHANGELOG with release notes
+# 1. Update CHANGELOG: convert ### [Unreleased] header to ### vX.Y.Z (YYYY-MM-DD)
 # 2. Commit changes
 git add CHANGELOG
-git commit -m "docs: update CHANGELOG for v0.41.0"
+git commit -m "docs: update CHANGELOG for vX.Y.Z"
 
-# 3. Tag and push
-git tag -a v0.41.0 -m "v0.41.0"
-git push origin main v0.41.0
+# 3. Tag and push (version is auto-injected from the tag by goreleaser ldflags)
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin main vX.Y.Z
 ```
 
 ### Release Candidate Workflow
@@ -444,23 +444,23 @@ For significant releases, use release candidates:
 
 ```bash
 # RC1
-git tag -a v0.40.0-rc.1 -m "v0.40.0-rc.1"
-git push origin v0.40.0-rc.1
+git tag -a vX.Y.Z-rc.1 -m "vX.Y.Z-rc.1"
+git push origin vX.Y.Z-rc.1
 
 # If issues are found, fix them and tag RC2
-git tag -a v0.40.0-rc.2 -m "v0.40.0-rc.2"
-git push origin v0.40.0-rc.2
+git tag -a vX.Y.Z-rc.2 -m "vX.Y.Z-rc.2"
+git push origin vX.Y.Z-rc.2
 
 # When stable, tag final release
-git tag -a v0.40.0 -m "v0.40.0"
-git push origin main v0.40.0
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin main vX.Y.Z
 ```
 
 ### Goreleaser
 
 Tags trigger GitHub Actions which run goreleaser:
-- RC tags (e.g., `v0.40.0-rc.1`) create pre-release builds marked as "Pre-release"
-- Final tags (e.g., `v0.40.0`) create production releases
+- RC tags (e.g., `vX.Y.Z-rc.1`) create pre-release builds marked as "Pre-release"
+- Final tags (e.g., `vX.Y.Z`) create production releases
 
 ### Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ feat: add Redis TLS support
 
 fix: resolve template cache invalidation on SIGHUP
 
-docs: update installation guide for v0.40.0
+docs: update installation guide for vX.Y.Z
 
 refactor: extract command execution into separate module
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ This creates `bin/confd` with the Git SHA embedded via ldflags.
 
 ```bash
 ./bin/confd --version
-# Output: confd 0.40.0-rc.1 (Git SHA: abc1234, Go Version: go1.26.3)
+# Output: confd 0.41.2 (Git SHA: abc1234, Go Version: go1.26.3)
 ```
 
 ### Project Structure
@@ -571,17 +571,15 @@ See [Release Checklist](release-checklist.md) for detailed instructions.
 make test
 make build
 
-# 2. Update version in cmd/confd/version.go
-# For RC: "0.40.0-rc.1"
-# For release: "0.40.0"
+# 2. Update CHANGELOG: convert ### [Unreleased] header to ### vX.Y.Z (YYYY-MM-DD)
 
-# 3. Update docs/installation.md with new version
+# 3. Update docs/installation.md and docs/docker.md with the new version
 
-# 4. Commit and tag
-git add cmd/confd/version.go docs/installation.md
-git commit -m "chore: bump version to 0.40.0"
-git tag -a v0.40.0 -m "v0.40.0"
-git push origin main v0.40.0
+# 4. Commit and tag (version is auto-injected from the tag by goreleaser ldflags)
+git add CHANGELOG docs/installation.md docs/docker.md
+git commit -m "docs: update CHANGELOG for vX.Y.Z"
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin main vX.Y.Z
 
 # 5. GitHub Actions runs goreleaser automatically
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -24,9 +24,9 @@ docker pull ghcr.io/abtreece/confd:latest
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `v0.40.0` | Specific version |
-| `v0.40.0-amd64` | Architecture-specific (amd64) |
-| `v0.40.0-arm64` | Architecture-specific (arm64) |
+| `v0.41.2` | Specific version |
+| `v0.41.2-amd64` | Architecture-specific (amd64) |
+| `v0.41.2-arm64` | Architecture-specific (arm64) |
 
 ## Image Details
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ confd provides native packages for Debian/Ubuntu (.deb) and RHEL/Fedora/CentOS (
 
 ```bash
 # Download the latest release (replace VERSION and ARCH as needed)
-VERSION=0.40.0
+VERSION=0.41.2
 ARCH=amd64  # or arm64
 
 curl -LO "https://github.com/abtreece/confd/releases/download/v${VERSION}/confd_${VERSION}_linux_${ARCH}.deb"
@@ -19,7 +19,7 @@ sudo dpkg -i "confd_${VERSION}_linux_${ARCH}.deb"
 
 ```bash
 # Download the latest release (replace VERSION and ARCH as needed)
-VERSION=0.40.0
+VERSION=0.41.2
 ARCH=x86_64  # or aarch64
 
 curl -LO "https://github.com/abtreece/confd/releases/download/v${VERSION}/confd-${VERSION}-1.${ARCH}.rpm"
@@ -79,10 +79,10 @@ confd ships binaries for OS X, Linux, and Windows for both amd64 and arm64 archi
 
 ```bash
 # For Intel Macs (amd64)
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-darwin-amd64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.41.2/confd-v0.41.2-darwin-amd64.tar.gz | tar -xz -C /usr/local/bin/
 
 # For Apple Silicon (arm64)
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-darwin-arm64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.41.2/confd-v0.41.2-darwin-arm64.tar.gz | tar -xz -C /usr/local/bin/
 ```
 
 #### Linux
@@ -90,16 +90,16 @@ curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40
 Download and extract the binary:
 ```bash
 # For amd64
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-amd64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.41.2/confd-v0.41.2-linux-amd64.tar.gz | tar -xz -C /usr/local/bin/
 
 # For arm64
-curl -SL https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/
+curl -SL https://github.com/abtreece/confd/releases/download/v0.41.2/confd-v0.41.2-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/
 ```
 
 Or manually:
 ```bash
-wget https://github.com/abtreece/confd/releases/download/v0.40.0/confd-v0.40.0-linux-amd64.tar.gz
-tar -xzf confd-v0.40.0-linux-amd64.tar.gz
+wget https://github.com/abtreece/confd/releases/download/v0.41.2/confd-v0.41.2-linux-amd64.tar.gz
+tar -xzf confd-v0.41.2-linux-amd64.tar.gz
 mv confd /usr/local/bin/
 ```
 
@@ -129,8 +129,8 @@ docker run --rm \
 
 Available image tags:
 - `latest` - Latest stable release
-- `v0.40.0` - Specific version
-- `v0.40.0-amd64`, `v0.40.0-arm64` - Architecture-specific images
+- `v0.41.2` - Specific version
+- `v0.41.2-amd64`, `v0.41.2-arm64` - Architecture-specific images
 
 See [Docker documentation](docker.md) for complete usage examples including Docker Compose and Kubernetes.
 
@@ -139,7 +139,7 @@ See [Docker documentation](docker.md) for complete usage examples including Dock
 To install confd in your own Docker image:
 
 ```dockerfile
-ARG CONFD_VERSION=0.40.0
+ARG CONFD_VERSION=0.41.2
 RUN CONFD_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
     && curl -SL "https://github.com/abtreece/confd/releases/download/v${CONFD_VERSION}/confd-v${CONFD_VERSION}-linux-${CONFD_ARCH}.tar.gz" | tar -xz -C /usr/local/bin/ \
     && confd --version

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -79,21 +79,21 @@ For significant releases, use release candidates to allow testing before the fin
 ### RC Process
 
 ```bash
-# 1. Update docs/installation.md with RC version
+# 1. Update docs/installation.md and docs/docker.md with the RC version
 
 # 2. Commit and tag
 git add docs/
-git commit -m "docs: update for 0.40.0-rc.1"
-git tag -a v0.40.0-rc.1 -m "v0.40.0-rc.1"
-git push origin main v0.40.0-rc.1
+git commit -m "docs: update for vX.Y.Z-rc.1"
+git tag -a vX.Y.Z-rc.1 -m "vX.Y.Z-rc.1"
+git push origin main vX.Y.Z-rc.1
 
 # 3. If issues are found, fix them, then release rc.2
-git tag -a v0.40.0-rc.2 -m "v0.40.0-rc.2"
-git push origin main v0.40.0-rc.2
+git tag -a vX.Y.Z-rc.2 -m "vX.Y.Z-rc.2"
+git push origin main vX.Y.Z-rc.2
 
 # 4. When stable, release final version
-git tag -a v0.40.0 -m "v0.40.0"
-git push origin main v0.40.0
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin main vX.Y.Z
 ```
 
 ### When to Use RCs
@@ -105,8 +105,8 @@ git push origin main v0.40.0
 
 ### RC vs Standard Release
 
-- **RC tags** (e.g., `v0.40.0-rc.1`) create pre-release builds marked as "Pre-release" on GitHub
-- **Final tags** (e.g., `v0.40.0`) create production releases
+- **RC tags** (e.g., `vX.Y.Z-rc.1`) create pre-release builds marked as "Pre-release" on GitHub
+- **Final tags** (e.g., `vX.Y.Z`) create production releases
 
 ## Manual Release (If Needed)
 


### PR DESCRIPTION
## Summary

Documentation audit after v0.41.2 release. Two classes of fixes:

### 1. Bump concrete user-facing version examples
- `docs/installation.md` — install URLs, RPM/DEB names, Docker tags, Dockerfile `ARG`
- `docs/docker.md` — image-tag table
- `docs/development.md` — `--version` sample output

All updated from `v0.40.0` → `v0.41.2`.

### 2. Genericize release-process examples to `vX.Y.Z` placeholders

The release-workflow docs hardcoded `v0.40.0`/`v0.40.0-rc.1` in `git tag`/`git push` examples. Those examples are illustrative — they don't refer to a current artifact — so pinning them to a version means they go stale every release. Switched to `vX.Y.Z` / `vX.Y.Z-rc.N` placeholders in:
- `CLAUDE.md`
- `CONTRIBUTING.md`
- `docs/development.md`
- `docs/release-checklist.md`
- `.github/workflows/release.yml` (workflow_dispatch input description)

### 3. Correct a wrong step

`docs/development.md` and the release-process examples instructed editing `cmd/confd/version.go` during a release. That file is ldflag-injected by goreleaser at build time — no manual edits required. Project `CLAUDE.md` already documents this; the dev-docs were just out of sync. Removed the step and updated the recipe to add CHANGELOG + installation.md instead.

### Audited but not changed
- CLI flags, backends list, watch-mode matrix, template functions, metrics names, Go toolchain version (1.26.3), architecture diagrams — all accurate.
- README has no pinned versions, no changes needed.

## Test plan

- [ ] Docs only, no code changes